### PR TITLE
[TISDEV-5036] Enable prometheus for monitoring

### DIFF
--- a/profile-service/pom.xml
+++ b/profile-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>profile-service</artifactId>
-  <version>2.8.6</version>
+  <version>2.9.0</version>
   <packaging>war</packaging>
   <name>profile-service</name>
 
@@ -105,6 +105,21 @@
 
   <dependencies>
 
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient</artifactId>
+      <version>${prometheus-simpleclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_dropwizard</artifactId>
+      <version>${prometheus-simpleclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient_servlet</artifactId>
+      <version>${prometheus-simpleclient.version}</version>
+    </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-hibernate5</artifactId>

--- a/profile-service/src/main/resources/config/application-prod.yml
+++ b/profile-service/src/main/resources/config/application-prod.yml
@@ -111,7 +111,7 @@ jhipster:
             port: 2003
             prefix: profile
         prometheus:
-            enabled: false
+            enabled: true
             endpoint: /prometheusMetrics
         logs: # Reports Dropwizard metrics in the logs
             enabled: false

--- a/profile-service/src/main/resources/config/application.yml
+++ b/profile-service/src/main/resources/config/application.yml
@@ -29,7 +29,7 @@ spring:
         # The commented value for `active` can be replaced with valid Spring profiles to load.
         # Otherwise, it will be filled in by maven when building the WAR file
         # Either way, it can be overridden by `--spring.profiles.active` value passed in the commandline or `-Dspring.profiles.active` set in `JAVA_OPTS`
-        active: prod
+        active: prod,prometheus
     jackson:
         serialization.write_dates_as_timestamps: false
     jpa:


### PR DESCRIPTION
We need to be able to monitor JMX stats so we can better utilise performance and tune our applications. To do this we need to export out metrics from the applications, push them to promethus and then capture them in grafana.

That we can we better understand what's going on with garbage collection and problems with heap sizes.

To do this we've exposed the built in metrics exporter of jhipster which allows us to then pick this up from the /promethusMetrics endpoint from prometheus.

Then we can pick these up with grafana.