### PR TITLE
[TISDEV-5009] Add document management r w permissions to Hee Admin role

### DIFF
--- a/profile-service/pom.xml
+++ b/profile-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>profile-service</artifactId>
-  <version>2.9.0</version>
+  <version>2.9.1</version>
   <packaging>war</packaging>
   <name>profile-service</name>
 

--- a/profile-service/src/main/resources/db/migration/V7.2__add_doc_management_perms_to_HEEadminRole.sql
+++ b/profile-service/src/main/resources/db/migration/V7.2__add_doc_management_perms_to_HEEadminRole.sql
@@ -1,0 +1,5 @@
+INSERT INTO `RolePermission` (`roleName`,`permissionName`)
+VALUES
+('HEE Admin','documentmanager:view:entities'),
+('HEE Admin','documentmanager:add:modify:entities')
+ON DUPLICATE KEY UPDATE `roleName` = `roleName`;


### PR DESCRIPTION
All users with the Hee Admin role require the permissions of:
documentmanager:add:modify:entities
ocumentmanager:view:entities
Added via flyway