### PR TITLE
Fix PathVariable with dot getting truncated issue.

### DIFF
--- a/profile-service/pom.xml
+++ b/profile-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>profile-service</artifactId>
-  <version>3.1.2</version>
+  <version>3.1.3</version>
   <packaging>war</packaging>
   <name>profile-service</name>
 

--- a/profile-service/src/main/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResource.java
+++ b/profile-service/src/main/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResource.java
@@ -175,7 +175,7 @@ public class HeeUserResource {
    * @return the ResponseEntity with status 200 (OK) and with body the heeUserDTO, or with status
    * 404 (Not Found)
    */
-  @GetMapping("/hee-users/{name}")
+  @GetMapping("/hee-users/{name:.+}")
   @Timed
   @PreAuthorize("hasAuthority('profile:view:entities')")
   public ResponseEntity<HeeUserDTO> getHeeUser(@PathVariable String name) {
@@ -201,7 +201,7 @@ public class HeeUserResource {
    * @param name the name of the heeUserDTO to delete
    * @return the ResponseEntity with status 200 (OK)
    */
-  @DeleteMapping("/hee-users/{name}")
+  @DeleteMapping("/hee-users/{name:.+}")
   @Timed
   @PreAuthorize("hasAuthority('profile:delete:entities')")
   public ResponseEntity<Void> deleteHeeUser(@PathVariable String name) {

--- a/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResourceIntTest.java
+++ b/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResourceIntTest.java
@@ -355,6 +355,7 @@ public class HeeUserResourceIntTest {
   @Transactional
   public void deleteHeeUser() throws Exception {
     // Initialize the database
+    heeUser.setName("test@hee.nhs.uk");
     heeUserRepository.saveAndFlush(heeUser);
     int databaseSizeBeforeDelete = heeUserRepository.findAll().size();
 

--- a/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResourceIntTest2.java
+++ b/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResourceIntTest2.java
@@ -41,7 +41,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 public class HeeUserResourceIntTest2 {
 
   private static final String TESTNAME_1 = "TESTNAME1";
-  private static final String TESTNAME_2 = "TESTNAME2";
+  private static final String TESTNAME_2 = "TESTNAME2@hee.nhs.uk";
   @MockBean
   private HeeUserRepository heeUserRepositoryMock;
   @MockBean


### PR DESCRIPTION
Spring MVC @PathVariable with dot(.) is getting truncated.

In HeeUser table, the primary key is the name which could be an email address. So need to deal with the dot. 

This problem causes failing when we try to delete a user in UserManagement with the name is formatted XX.XX