### PR TITLE
chore: Add Sentry error tracking configuration

### DIFF
--- a/profile-service/pom.xml
+++ b/profile-service/pom.xml
@@ -393,6 +393,11 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.sentry</groupId>
+      <artifactId>sentry-spring</artifactId>
+      <version>1.7.30</version>
+    </dependency>
     <!-- jhipster-needle-maven-add-dependency -->
   </dependencies>
   <build>

--- a/profile-service/src/main/java/com/transformuk/hee/tis/profile/config/SentryConfiguration.java
+++ b/profile-service/src/main/java/com/transformuk/hee/tis/profile/config/SentryConfiguration.java
@@ -1,0 +1,22 @@
+package com.transformuk.hee.tis.profile.config;
+
+import io.sentry.spring.SentryExceptionResolver;
+import io.sentry.spring.SentryServletContextInitializer;
+import org.springframework.boot.web.servlet.ServletContextInitializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+@Configuration
+public class SentryConfiguration {
+
+  @Bean
+  public HandlerExceptionResolver sentryExceptionResolver() {
+    return new SentryExceptionResolver();
+  }
+
+  @Bean
+  public ServletContextInitializer sentryServletContextInitilizer() {
+    return new SentryServletContextInitializer();
+  }
+}

--- a/profile-service/src/main/resources/sentry.properties
+++ b/profile-service/src/main/resources/sentry.properties
@@ -1,0 +1,1 @@
+dsn=https://183569ec991a465e8b61adc11ee1e280@sentry.io/3458499


### PR DESCRIPTION
Add Sentry error reporting using `sentry-spring`, configuration is done
in SentryConfiguration with two beans set up as per the Sentry
installation guide. Provide the project's DSN using the
sentry.properties file.

TISNEW-3904