### PR TITLE
fix: Remove sentry.properties, set during deploy

### DIFF
--- a/profile-service/pom.xml
+++ b/profile-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>profile-service</artifactId>
-  <version>3.2.0</version>
+  <version>3.2.1</version>
   <packaging>war</packaging>
   <name>profile-service</name>
 

--- a/profile-service/src/main/resources/sentry.properties
+++ b/profile-service/src/main/resources/sentry.properties
@@ -1,1 +1,0 @@
-dsn=https://183569ec991a465e8b61adc11ee1e280@sentry.io/3458499


### PR DESCRIPTION
Delete sentry.properties, the dsn can be provided using the `SENTRY_DSN`
environmental variable during deployment, this technique is needed to
set the Sentry environment value so may as well be kept together.

Update the profile-service version from 3.2.0 to 3.2.1.

TISNEW-3904