### PR TITLE
Fix update reval role name

### DIFF
--- a/profile-service/pom.xml
+++ b/profile-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>profile-service</artifactId>
-  <version>3.3.8</version>
+  <version>3.3.9</version>
   <packaging>war</packaging>
   <name>profile-service</name>
 

--- a/profile-service/src/main/resources/db/migration/V9.14__update_reval_role_name.sql
+++ b/profile-service/src/main/resources/db/migration/V9.14__update_reval_role_name.sql
@@ -1,0 +1,22 @@
+-- Get rid of the existing roles and detach them from the users
+
+DELETE Role, UserRole
+FROM Role
+	INNER JOIN UserRole
+	ON Role.name = UserRole.roleName
+WHERE Role.name
+  IN
+  ('RevalSiteAdmin',
+	'RevalSuperAdmin',
+	'RevalTISAdmin1',
+	'RevalTISAdmin2',
+	'RevalTISAdmin3');
+
+-- add the new roles
+
+INSERT INTO `Role` (`name`)
+VALUES
+      ('RevalApprover'),
+      ('RevalAdmin'),
+      ('RevalObserver')
+ON DUPLICATE KEY UPDATE `name` = `name`;

--- a/profile-service/src/main/resources/db/migration/V9.14__update_reval_role_name.sql
+++ b/profile-service/src/main/resources/db/migration/V9.14__update_reval_role_name.sql
@@ -1,10 +1,10 @@
 -- Get rid of the existing roles and detach them from the users
 
-DELETE Role, UserRole
-FROM Role
-	INNER JOIN UserRole
-	ON Role.name = UserRole.roleName
-WHERE Role.name
+DELETE `Role`, `UserRole`
+FROM `Role`
+	INNER JOIN `UserRole`
+	ON `Role`.`name` = `UserRole`.`roleName`
+WHERE `Role`.`name`
   IN
   ('RevalSiteAdmin',
 	'RevalSuperAdmin',


### PR DESCRIPTION
RevalTISAdmin1, RevalTISAdmin2, RevalTISAdmin3 role names were not meaningful. So are replacing them by meaningful role name as RevalApprover, RevalAdmin, RevalObserver.

TIS21-2227