### PR TITLE
fix: add debug logging for duplicate GMC

### DIFF
--- a/profile-service/pom.xml
+++ b/profile-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>profile-service</artifactId>
-  <version>3.4.5</version>
+  <version>3.4.6</version>
   <packaging>war</packaging>
   <name>profile-service</name>
 

--- a/profile-service/src/test/java/com/transformuk/hee/tis/profile/service/TraineeProfileServiceTest.java
+++ b/profile-service/src/test/java/com/transformuk/hee/tis/profile/service/TraineeProfileServiceTest.java
@@ -58,6 +58,36 @@ public class TraineeProfileServiceTest {
   }
 
   @Test
+  public void shouldSkipDuplicateIds() {
+    RegistrationRequest request = new RegistrationRequest();
+    request.setGmcNumber(EXISTING_GMC_NUMBER);
+
+    RegistrationRequest dupeRequest1 = new RegistrationRequest();
+    dupeRequest1.setGmcNumber("dupedGmc");
+    RegistrationRequest dupeRequest2 = new RegistrationRequest();
+    dupeRequest2.setGmcNumber("dupedGmc");
+
+    List<String> gmcNumbers = newArrayList(EXISTING_GMC_NUMBER);
+    TraineeProfile existingTraineeProfile = new TraineeProfile(1L, EXISTING_GMC_NUMBER);
+    existingTraineeProfile.setActive(true);
+    existingTraineeProfile.setDesignatedBodyCode(DBC);
+
+    // given
+    given(traineeProfileRepository.findByDesignatedBodyCode(DBC))
+        .willReturn(newArrayList(existingTraineeProfile));
+    given(traineeProfileRepository.findByGmcNumberIn(gmcNumbers))
+        .willReturn(newArrayList(existingTraineeProfile));
+
+    // when
+    List<TraineeProfile> traineeProfiles = service.findOrCreate(DBC,
+        newArrayList(request, dupeRequest1, dupeRequest2));
+
+    // then
+    assertThat(traineeProfiles).isEqualTo(newArrayList(existingTraineeProfile));
+    verify(traineeProfileRepository, times(1)).findByGmcNumberIn(gmcNumbers);
+  }
+
+  @Test
   public void shouldCreateIfNotExists() {
     RegistrationRequest request = new RegistrationRequest();
     request.setGmcNumber(EXISTING_GMC_NUMBER);


### PR DESCRIPTION
A duplicate key exception is thrown when duplicate GMC numbers are
provided to `TraineeProfileService.findOrCreate()`, add some additional
logging to log duplicates instead of throwing.

TIS21-3397