### PR TITLE
chore: remove old roles & permissions for Reval

### DIFF
--- a/profile-service/src/main/resources/db/migration/common/V9.22__remove_roles_permissions_for_old_reval.sql
+++ b/profile-service/src/main/resources/db/migration/common/V9.22__remove_roles_permissions_for_old_reval.sql
@@ -1,75 +1,75 @@
 DELETE FROM `RolePermission`
 WHERE `permissionName` IN (
-  "concerns:change:add:concern",
-  "concerns:data:sync",
-  "concerns:register:trainee",
-  "concerns:see:dbc:concerns",
-  "concerns:see:trainee:concerns",
-  "connection:discrepancies:manage",
-  "connection:discrepancies:view",
-  "revalidation:assign:admin",
-  "revalidation:change:add:note",
-  "revalidation:data:sync",
-  "revalidation:manual:archive",
-  "revalidation:provide:recommendation",
-  "revalidation:register:trainee",
-  "revalidation:see:dbc:report",
-  "revalidation:submit:on:behalf:of:ro",
-  "revalidation:submit:to:gmc",
-  "revalidation:submit:to:ro:review"
+  'concerns:change:add:concern',
+  'concerns:data:sync',
+  'concerns:register:trainee',
+  'concerns:see:dbc:concerns',
+  'concerns:see:trainee:concerns',
+  'connection:discrepancies:manage',
+  'connection:discrepancies:view',
+  'revalidation:assign:admin',
+  'revalidation:change:add:note',
+  'revalidation:data:sync',
+  'revalidation:manual:archive',
+  'revalidation:provide:recommendation',
+  'revalidation:register:trainee',
+  'revalidation:see:dbc:report',
+  'revalidation:submit:on:behalf:of:ro',
+  'revalidation:submit:to:gmc',
+  'revalidation:submit:to:ro:review'
 );
 
 DELETE FROM `PermissionRequires`
 WHERE `permission` IN (
-  "concerns:change:add:concern",
-  "connection:discrepancies:manage",
-  "revalidation:assign:admin",
-  "revalidation:change:add:note",
-  "revalidation:provide:recommendation",
-  "revalidation:submit:on:behalf:of:ro",
-  "revalidation:submit:to:gmc",
-  "revalidation:submit:to:ro:review"
+  'concerns:change:add:concern',
+  'connection:discrepancies:manage',
+  'revalidation:assign:admin',
+  'revalidation:change:add:note',
+  'revalidation:provide:recommendation',
+  'revalidation:submit:on:behalf:of:ro',
+  'revalidation:submit:to:gmc',
+  'revalidation:submit:to:ro:review'
 );
 
 DELETE FROM `Permission`
 WHERE `name` IN (
-  "concerns:change:add:concern",
-  "concerns:data:sync",
-  "concerns:register:trainee",
-  "concerns:see:dbc:concerns",
-  "concerns:see:trainee:concerns",
-  "connection:discrepancies:manage",
-  "connection:discrepancies:view",
-  "revalidation:assign:admin",
-  "revalidation:change:add:note",
-  "revalidation:data:sync",
-  "revalidation:manual:archive",
-  "revalidation:provide:recommendation",
-  "revalidation:register:trainee",
-  "revalidation:see:dbc:report",
-  "revalidation:submit:on:behalf:of:ro",
-  "revalidation:submit:to:gmc",
-  "revalidation:submit:to:ro:review"
+  'concerns:change:add:concern',
+  'concerns:data:sync',
+  'concerns:register:trainee',
+  'concerns:see:dbc:concerns',
+  'concerns:see:trainee:concerns',
+  'connection:discrepancies:manage',
+  'connection:discrepancies:view',
+  'revalidation:assign:admin',
+  'revalidation:change:add:note',
+  'revalidation:data:sync',
+  'revalidation:manual:archive',
+  'revalidation:provide:recommendation',
+  'revalidation:register:trainee',
+  'revalidation:see:dbc:report',
+  'revalidation:submit:on:behalf:of:ro',
+  'revalidation:submit:to:gmc',
+  'revalidation:submit:to:ro:review'
 );
 
 DELETE FROM `UserRole`
 WHERE `roleName` IN (
-  "ConcernsAdmin",
-  "ConcernsObserver",
-  "ConnectionDiscrepanciesManager",
-  "RVAdmin",
-  "RVManager",
-  "RVObserver",
-  "RevalBeta"
+  'ConcernsAdmin',
+  'ConcernsObserver',
+  'ConnectionDiscrepanciesManager',
+  'RVAdmin',
+  'RVManager',
+  'RVObserver',
+  'RevalBeta'
 );
 
 DELETE FROM `Role`
 WHERE `name` IN (
-  "ConcernsAdmin",
-  "ConcernsObserver",
-  "ConnectionDiscrepanciesManager",
-  "RVAdmin",
-  "RVManager",
-  "RVObserver",
-  "RevalBeta"
+  'ConcernsAdmin',
+  'ConcernsObserver',
+  'ConnectionDiscrepanciesManager',
+  'RVAdmin',
+  'RVManager',
+  'RVObserver',
+  'RevalBeta'
 );

--- a/profile-service/src/main/resources/db/migration/common/V9.22__remove_roles_permissions_for_old_reval.sql
+++ b/profile-service/src/main/resources/db/migration/common/V9.22__remove_roles_permissions_for_old_reval.sql
@@ -1,0 +1,75 @@
+DELETE FROM `RolePermission`
+WHERE `permissionName` IN (
+  "concerns:change:add:concern",
+  "concerns:data:sync",
+  "concerns:register:trainee",
+  "concerns:see:dbc:concerns",
+  "concerns:see:trainee:concerns",
+  "connection:discrepancies:manage",
+  "connection:discrepancies:view",
+  "revalidation:assign:admin",
+  "revalidation:change:add:note",
+  "revalidation:data:sync",
+  "revalidation:manual:archive",
+  "revalidation:provide:recommendation",
+  "revalidation:register:trainee",
+  "revalidation:see:dbc:report",
+  "revalidation:submit:on:behalf:of:ro",
+  "revalidation:submit:to:gmc",
+  "revalidation:submit:to:ro:review"
+);
+
+DELETE FROM `PermissionRequires`
+WHERE `permission` IN (
+  "concerns:change:add:concern",
+  "connection:discrepancies:manage",
+  "revalidation:assign:admin",
+  "revalidation:change:add:note",
+  "revalidation:provide:recommendation",
+  "revalidation:submit:on:behalf:of:ro",
+  "revalidation:submit:to:gmc",
+  "revalidation:submit:to:ro:review"
+);
+
+DELETE FROM `Permission`
+WHERE `name` IN (
+  "concerns:change:add:concern",
+  "concerns:data:sync",
+  "concerns:register:trainee",
+  "concerns:see:dbc:concerns",
+  "concerns:see:trainee:concerns",
+  "connection:discrepancies:manage",
+  "connection:discrepancies:view",
+  "revalidation:assign:admin",
+  "revalidation:change:add:note",
+  "revalidation:data:sync",
+  "revalidation:manual:archive",
+  "revalidation:provide:recommendation",
+  "revalidation:register:trainee",
+  "revalidation:see:dbc:report",
+  "revalidation:submit:on:behalf:of:ro",
+  "revalidation:submit:to:gmc",
+  "revalidation:submit:to:ro:review"
+);
+
+DELETE FROM `UserRole`
+WHERE `roleName` IN (
+  "ConcernsAdmin",
+  "ConcernsObserver",
+  "ConnectionDiscrepanciesManager",
+  "RVAdmin",
+  "RVManager",
+  "RVObserver",
+  "RevalBeta"
+);
+
+DELETE FROM `Role`
+WHERE `name` IN (
+  "ConcernsAdmin",
+  "ConcernsObserver",
+  "ConnectionDiscrepanciesManager",
+  "RVAdmin",
+  "RVManager",
+  "RVObserver",
+  "RevalBeta"
+);

--- a/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/PermissionResourceIntTest.java
+++ b/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/PermissionResourceIntTest.java
@@ -129,7 +129,7 @@ public class PermissionResourceIntTest {
     int databaseSizeBeforeCreate = permissionRepository.findAll().size();
 
     // Create the Permission with an existing ID
-    this.permission.setName("revalidation:data:sync");
+    this.permission.setName("revalidation:see:dbc:trainees");
     PermissionDTO permission = permissionMapper.permissionToPermissionDTO(this.permission);
 
     // Creating a permission with the same name will do nothing but not fail

--- a/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/RoleResourceIntTest.java
+++ b/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/RoleResourceIntTest.java
@@ -168,7 +168,7 @@ public class RoleResourceIntTest {
     int dbPermissionSizeBeforeCreate = permissionRepository.findAll().size();
 
     // Create the Role with an existing ID
-    role.setName("RVAdmin");
+    role.setName("RevalAdmin");
     RoleDTO roleDTO = roleMapper.roleToRoleDTO(role);
 
     // Creating a role with the same name will do nothing but not fail

--- a/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/TestUtil.java
+++ b/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/TestUtil.java
@@ -43,7 +43,7 @@ public class TestUtil {
   public static final Boolean DEFAULT_ACTIVE = false;
   public static final Boolean UPDATED_ACTIVE = true;
 
-  public static final String DEFAULT_ROLE = "RVAdmin";
+  public static final String DEFAULT_ROLE = "Hee Admin Revalidation";
   public static final String DEFAULT_DESIGNATED_CODE = "1-AIIDH1";
 
   /**


### PR DESCRIPTION
The only surviving permission for Reval is `revalidation:see:dbc:trainees`, which is used in TIS-ADMINS-UI to show Revalidation on the NavBar.

TIS21-4343