### PR TITLE
chore:add RevalBeta role back

### DIFF
--- a/profile-service/src/main/resources/db/migration/common/V9.23__add_RevalBeta_role_back.sql
+++ b/profile-service/src/main/resources/db/migration/common/V9.23__add_RevalBeta_role_back.sql
@@ -1,0 +1,2 @@
+INSERT INTO `Role`
+VALUES('RevalBeta');


### PR DESCRIPTION
the RevalBeta role was deleted when doing the cleanup (https://github.com/Health-Education-England/TIS-PROFILE/pull/264), but it's still needed for User Beta phase, so add it back.

TIS21-4630