### PR TITLE
feat: add TSS FormR view permission

### DIFF
--- a/profile-service/pom.xml
+++ b/profile-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>profile-service</artifactId>
-  <version>3.4.7</version>
+  <version>3.5.0</version>
   <packaging>war</packaging>
   <name>profile-service</name>
 

--- a/profile-service/src/main/resources/db/migration/common/V9.24__add_tss_formr_view_permission.sql
+++ b/profile-service/src/main/resources/db/migration/common/V9.24__add_tss_formr_view_permission.sql
@@ -1,0 +1,18 @@
+INSERT INTO `Permission` (`name`, `type`, `description`, `principal`, `resource`, `actions`, `effect`)
+VALUES
+    ('trainee-formr:view',
+     'PERSON',
+     'Can view submitted trainee form-r',
+     'tis:profile::user:',
+     'tis:people::person:',
+     'View',
+     'Allow')
+ON DUPLICATE KEY UPDATE `name` = `name`;
+
+INSERT INTO `RolePermission` (`roleName`, `permissionName`)
+VALUES
+    ('HEE Admin','trainee-formr:view'),
+    ('HEE Admin Revalidation','trainee-formr:view'),
+    ('HEE Admin Sensitive','trainee-formr:view'),
+    ('HEE TIS Admin','trainee-formr:view')
+ON DUPLICATE KEY UPDATE `roleName` = `roleName`;


### PR DESCRIPTION
Access to submitted Form Rs in TIS is currently too permissive, create a new permission to allow the viewing of Form Rs to be restricted to just roles who also have assessment and/or revalidation access.

TIS21-4743