### PR TITLE
build: use OIDC for AWS credentials

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -1,5 +1,9 @@
 name: CI CD Workflow
 
+permissions:
+  id-token: write
+  contents: read
+
 on:
   push:
     branches:
@@ -25,9 +29,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_MAVEN_USERNAME }}
-          aws-secret-access-key: ${{ secrets.AWS_MAVEN_PASSWORD }}
           aws-region: eu-west-1
+          role-to-assume: arn:aws:iam::430723991443:role/github-actions-deployer-role
 
       - name: Add CodeArtifact env var
         run: echo "CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain hee --domain-owner 430723991443 --query authorizationToken --output text)" >> $GITHUB_ENV
@@ -50,9 +53,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
+          role-to-assume: arn:aws:iam::430723991443:role/github-actions-deployer-role
 
       - name: Run tests
         run: mvn test
@@ -77,9 +79,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
+          role-to-assume: arn:aws:iam::430723991443:role/github-actions-deployer-role
 
       - name: Backup build artifacts
         run: |
@@ -106,9 +107,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_MAVEN_USERNAME }}
-          aws-secret-access-key: ${{ secrets.AWS_MAVEN_PASSWORD }}
           aws-region: eu-west-1
+          role-to-assume: arn:aws:iam::430723991443:role/github-actions-deployer-role
 
       - name: Add CodeArtifact env var
         run: echo "CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain hee --domain-owner 430723991443 --query authorizationToken --output text)" >> $GITHUB_ENV
@@ -135,9 +135,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
+          role-to-assume: arn:aws:iam::430723991443:role/github-actions-deployer-role
 
       - name: Log in to Amazon ECR
         id: login-ecr
@@ -165,9 +164,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
+          role-to-assume: arn:aws:iam::430723991443:role/github-actions-deployer-role
 
       - name: Log in to Amazon ECR
         id: login-ecr
@@ -205,9 +203,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
+          role-to-assume: arn:aws:iam::430723991443:role/github-actions-deployer-role
 
       - name: Log in to Amazon ECR
         id: login-ecr
@@ -245,9 +242,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: eu-west-2
+          role-to-assume: arn:aws:iam::430723991443:role/github-actions-deployer-role
 
       - name: Log in to Amazon ECR
         id: login-ecr


### PR DESCRIPTION
Remove the unused ecr and codeartifact user tokens and replace it with a role reference to the github-actions-deployer-role accessible using OIDC.

TIS21-4862