### PR TITLE
fix: flyway property naming

### DIFF
--- a/profile-service/pom.xml
+++ b/profile-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>profile-service</artifactId>
-  <version>3.5.2</version>
+  <version>3.5.3</version>
   <packaging>war</packaging>
   <name>profile-service</name>
 

--- a/profile-service/src/main/resources/config/application-stage.yml
+++ b/profile-service/src/main/resources/config/application-stage.yml
@@ -3,5 +3,5 @@ spring:
         url: jdbc:mysql://${DBHOST}:${DBPORT}/${DBNAME}?useUnicode=true&characterEncoding=utf8&useSSL=${USE_SSL}
         username: ${DBUSER}
         password: ${DBPASSWORD}
-flyway:
-    locations: classpath:db/migration/common,classpath:db/migration/stage
+    flyway:
+        locations: classpath:db/migration/common,classpath:db/migration/stage

--- a/profile-service/src/test/resources/config/application.yml
+++ b/profile-service/src/test/resources/config/application.yml
@@ -28,6 +28,22 @@ spring:
     password:
   flyway:
     enabled: true # Enable flyway.
+    baseline-description: #
+    baseline-version: 1 # version to start migration
+    baseline-on-migrate: true
+    check-location: false # Check that migration scripts location exists.
+    clean-on-validation-error: false
+    ignore-failed-future-migration: true
+    init-sqls: # SQL statements to execute to initialize a connection immediately after obtaining it.
+    locations: classpath:db/migration/common
+    out-of-order: true
+    password:
+    schemas: ${DBNAME:profile}
+    sql-migration-prefix: V
+    sql-migration-suffix: .sql
+    url: ${spring.datasource.url}
+    user: sa
+    table: schema_version
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
     database: H2
@@ -48,23 +64,6 @@ spring:
   mvc:
     favicon:
       enabled: false
-flyway:
-  baseline-description: #
-  baseline-version: 1 # version to start migration
-  baseline-on-migrate: true
-  check-location: false # Check that migration scripts location exists.
-  clean-on-validation-error: false
-  ignore-failed-future-migration: true
-  init-sqls: # SQL statements to execute to initialize a connection immediately after obtaining it.
-  locations: classpath:db/migration/common
-  out-of-order: true
-  password:
-  schemas: ${DBNAME:profile}
-  sql-migration-prefix: V
-  sql-migration-suffix: .sql
-  url: ${spring.datasource.url}
-  user: sa
-  table: schema_version
 security:
   basic:
     enabled: false


### PR DESCRIPTION
The flyway property naming has changed from `flyway.x` to `spring.flyway.x`.
Update application-stage.yml to correctly nest the flyway properties.

NO-TICKET