### PR TITLE
fix: flyway property naming

### DIFF
--- a/profile-service/pom.xml
+++ b/profile-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>profile-service</artifactId>
-  <version>3.5.2</version>
+  <version>3.5.3</version>
   <packaging>war</packaging>
   <name>profile-service</name>
 

--- a/profile-service/src/main/resources/config/application-stage.yml
+++ b/profile-service/src/main/resources/config/application-stage.yml
@@ -3,5 +3,5 @@ spring:
         url: jdbc:mysql://${DBHOST}:${DBPORT}/${DBNAME}?useUnicode=true&characterEncoding=utf8&useSSL=${USE_SSL}
         username: ${DBUSER}
         password: ${DBPASSWORD}
-flyway:
-    locations: classpath:db/migration/common,classpath:db/migration/stage
+    flyway:
+        locations: classpath:db/migration/common,classpath:db/migration/stage

--- a/profile-service/src/test/resources/config/application.yml
+++ b/profile-service/src/test/resources/config/application.yml
@@ -26,8 +26,6 @@ spring:
     name:
     username: sa
     password:
-  flyway:
-    enabled: true # Enable flyway.
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
     database: H2
@@ -48,23 +46,20 @@ spring:
   mvc:
     favicon:
       enabled: false
-flyway:
-  baseline-description: #
-  baseline-version: 1 # version to start migration
-  baseline-on-migrate: true
-  check-location: false # Check that migration scripts location exists.
-  clean-on-validation-error: false
-  ignore-failed-future-migration: true
-  init-sqls: # SQL statements to execute to initialize a connection immediately after obtaining it.
-  locations: classpath:db/migration/common
-  out-of-order: true
-  password:
-  schemas: ${DBNAME:profile}
-  sql-migration-prefix: V
-  sql-migration-suffix: .sql
-  url: ${spring.datasource.url}
-  user: sa
-  table: schema_version
+  flyway:
+    baseline-description: #
+    baseline-version: 1 # version to start migration
+    baseline-on-migrate: true
+    check-location: false # Check that migration scripts location exists.
+    clean-on-validation-error: false
+    enabled: true # Enable flyway.
+    ignore-failed-future-migration: true
+    init-sqls: # SQL statements to execute to initialize a connection immediately after obtaining it.
+    locations: classpath:db/migration
+    out-of-order: true
+    sql-migration-prefix: V
+    sql-migration-suffix: .sql
+    table: schema_version
 security:
   basic:
     enabled: false
@@ -72,5 +67,10 @@ security:
 server:
   port: 10344
   address: localhost
+
+logging:
+  level:
+    org.flywaydb: DEBUG
+    org.springframework.boot.autoconfigure.flyway: DEBUG
 
 application:

--- a/profile-service/src/test/resources/config/application.yml
+++ b/profile-service/src/test/resources/config/application.yml
@@ -68,9 +68,4 @@ server:
   port: 10344
   address: localhost
 
-logging:
-  level:
-    org.flywaydb: DEBUG
-    org.springframework.boot.autoconfigure.flyway: DEBUG
-
 application:


### PR DESCRIPTION
See https://github.com/Health-Education-England/TIS-PROFILE/pull/293
Flyway property naming has changed from `flyway.x` to `spring.flyway.x`. Update application-stage.yml to correctly nest the flyway properties.

Co-authored-by: Andy Dingley <judge40@users.noreply.github.com>

fix(test): run flyway with test datasource

Flyway was running against a datasource it created as it does in prod. Running flyway with the same datasource resolves test setup errors. Tests must run in the flyway initialised DB.

NO-CARD: Blocks changes needed for moving Auth providers