### PR TITLE
fix: JAXB xml bind conflict

### DIFF
--- a/profile-service/pom.xml
+++ b/profile-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>profile-service</artifactId>
-  <version>3.5.3</version>
+  <version>3.5.4</version>
   <packaging>war</packaging>
   <name>profile-service</name>
 
@@ -103,6 +103,12 @@
       <groupId>com.transformuk.hee</groupId>
       <artifactId>reference-client</artifactId>
       <version>4.1.8</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>uk.nhs.tis</groupId>


### PR DESCRIPTION
This excludes a reference-client transitive dependency: sun xml library. It conflicts with a later version used by hibernate. In some build environments, the earlier version is given preference.

NO-CARD: Blocks changes needed for moving Auth providers