### PR TITLE
chore(build): deploy built code to CodeArtifact

### DIFF
--- a/profile-api/pom.xml
+++ b/profile-api/pom.xml
@@ -60,4 +60,12 @@
       </plugin>
     </plugins>
   </build>
+
+  <distributionManagement>
+    <repository>
+      <id>codeartifact</id>
+      <name>CodeArtifact</name>
+      <url>https://hee-430723991443.d.codeartifact.eu-west-1.amazonaws.com/maven/Health-Education-England/</url>
+    </repository>
+  </distributionManagement>
 </project>

--- a/profile-client/pom.xml
+++ b/profile-client/pom.xml
@@ -94,4 +94,12 @@
       </plugin>
     </plugins>
   </build>
+
+  <distributionManagement>
+    <repository>
+      <id>codeartifact</id>
+      <name>CodeArtifact</name>
+      <url>https://hee-430723991443.d.codeartifact.eu-west-1.amazonaws.com/maven/Health-Education-England/</url>
+    </repository>
+  </distributionManagement>
 </project>


### PR DESCRIPTION
Not deploying the service. No projects should compile/run with it. We are not actively supporting running the service outside a container. A container with the service is pushed to the container repository.

NO-CARD: Blocks changes needed for moving Auth providers