### PR TITLE
feat/remove redundant password fields

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up build JDK
         uses: actions/setup-java@v4
@@ -153,7 +153,7 @@ jobs:
 
       - name: Log in to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Build, tag and push image to Amazon ECR
         env:
@@ -182,7 +182,7 @@ jobs:
 
       - name: Log in to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Create pre-prod task definition
         run: sed 's/${environment}/preprod/g' .aws/task-definition-template.json > .aws/task-definition-preprod.json
@@ -233,7 +233,7 @@ jobs:
 
       - name: Log in to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Create prod task definition
         run: sed 's/${environment}/prod/g' .aws/task-definition-template.json > .aws/task-definition-prod.json
@@ -284,7 +284,7 @@ jobs:
 
       - name: Log in to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Create NIMDTA task definition
         run: sed 's/${environment}/nimdta/g' .aws/task-definition-template.json > .aws/task-definition-nimdta.json

--- a/profile-api/pom.xml
+++ b/profile-api/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee</groupId>
   <artifactId>profile-api</artifactId>
-  <version>2.4.6</version>
+  <version>3.0.0</version>
   <packaging>jar</packaging>
 
   <properties>

--- a/profile-api/src/main/java/com/transformuk/hee/tis/profile/service/dto/HeeUserDTO.java
+++ b/profile-api/src/main/java/com/transformuk/hee/tis/profile/service/dto/HeeUserDTO.java
@@ -27,10 +27,6 @@ public class HeeUserDTO implements Serializable {
 
   private Boolean active;
 
-  private String password;
-
-  private Boolean isTemporaryPassword;
-
   private Set<RoleDTO> roles;
   private Set<String> designatedBodyCodes;
   private Set<UserTrustDTO> associatedTrusts;
@@ -40,8 +36,7 @@ public class HeeUserDTO implements Serializable {
   }
 
   public HeeUserDTO(String name, String firstName, String lastName, String gmcId,
-      String phoneNumber, String emailAddress, Boolean active,
-      String password, Boolean isTemporaryPassword, Set<RoleDTO> roles,
+      String phoneNumber, String emailAddress, Boolean active, Set<RoleDTO> roles,
       Set<String> designatedBodyCodes) {
     this.name = name;
     this.firstName = firstName;
@@ -50,8 +45,6 @@ public class HeeUserDTO implements Serializable {
     this.phoneNumber = phoneNumber;
     this.emailAddress = emailAddress;
     this.active = active;
-    this.password = password;
-    this.isTemporaryPassword = isTemporaryPassword;
     this.roles = roles;
     this.designatedBodyCodes = designatedBodyCodes;
   }
@@ -110,22 +103,6 @@ public class HeeUserDTO implements Serializable {
 
   public void setActive(Boolean active) {
     this.active = active;
-  }
-
-  public String getPassword() {
-    return password;
-  }
-
-  public void setPassword(String password) {
-    this.password = password;
-  }
-
-  public Boolean getTemporaryPassword() {
-    return isTemporaryPassword;
-  }
-
-  public void setTemporaryPassword(Boolean temporaryPassword) {
-    isTemporaryPassword = temporaryPassword;
   }
 
   public Set<RoleDTO> getRoles() {

--- a/profile-client/pom.xml
+++ b/profile-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee</groupId>
   <artifactId>profile-client</artifactId>
-  <version>3.2.0</version>
+  <version>3.2.1</version>
   <packaging>jar</packaging>
 
   <properties>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.transformuk.hee</groupId>
       <artifactId>profile-api</artifactId>
-      <version>2.4.6</version>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee</groupId>

--- a/profile-service/pom.xml
+++ b/profile-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>profile-service</artifactId>
-  <version>3.6.0</version>
+  <version>3.6.1</version>
   <packaging>war</packaging>
   <name>profile-service</name>
 
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>com.transformuk.hee</groupId>
       <artifactId>profile-api</artifactId>
-      <version>2.4.6</version>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.transformuk.hee</groupId>

--- a/profile-service/src/main/java/com/transformuk/hee/tis/profile/domain/HeeUser.java
+++ b/profile-service/src/main/java/com/transformuk/hee/tis/profile/domain/HeeUser.java
@@ -19,7 +19,6 @@ import javax.persistence.JoinColumn;
 import javax.persistence.JoinTable;
 import javax.persistence.ManyToMany;
 import javax.persistence.OneToMany;
-import javax.persistence.Transient;
 import javax.validation.constraints.NotNull;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -43,10 +42,6 @@ public class HeeUser implements Serializable {
   private String phoneNumber;
   private String emailAddress;
   private Boolean active;
-
-  private String password;
-
-  private Boolean isTemporaryPassword;
 
   private Set<Role> roles;
   private Set<String> designatedBodyCodes;
@@ -154,24 +149,6 @@ public class HeeUser implements Serializable {
 
   public void setActive(Boolean active) {
     this.active = active;
-  }
-
-  @Transient
-  public String getPassword() {
-    return password;
-  }
-
-  public void setPassword(String password) {
-    this.password = password;
-  }
-
-  @Transient
-  public Boolean getTemporaryPassword() {
-    return isTemporaryPassword;
-  }
-
-  public void setTemporaryPassword(Boolean temporaryPassword) {
-    isTemporaryPassword = temporaryPassword;
   }
 
   @ManyToMany(cascade = CascadeType.DETACH, fetch = FetchType.EAGER)

--- a/profile-service/src/main/java/com/transformuk/hee/tis/profile/validators/HeeUserValidator.java
+++ b/profile-service/src/main/java/com/transformuk/hee/tis/profile/validators/HeeUserValidator.java
@@ -12,7 +12,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
-import org.springframework.util.StringUtils;
 import org.springframework.web.client.HttpClientErrorException;
 
 /**
@@ -33,12 +32,12 @@ public class HeeUserValidator {
   /**
    * Validates given dbc codes are exists and matches.
    *
-   * @param dbcCodes
+   * @param dbCodes Designated Body Codes to validate
    * @throws CustomParameterizedException if any errors
    */
-  public void validateDBCIds(Set<String> dbcCodes) {
-    if (!CollectionUtils.isEmpty(dbcCodes)) {
-      dbcCodes.forEach(dbcCode -> {
+  public void validateDbcIds(Set<String> dbCodes) {
+    if (!CollectionUtils.isEmpty(dbCodes)) {
+      dbCodes.forEach(dbcCode -> {
         try {
           // if designated body is None then don't validate
           if (!dbcCode.equalsIgnoreCase(HeeUser.NONE)) {
@@ -50,13 +49,12 @@ public class HeeUserValidator {
         }
       });
     }
-
   }
 
   /**
-   * Validates given role name are exists and matches
+   * Validates given role names exist and matches
    *
-   * @param roles
+   * @param roles Roles to validate
    * @throws CustomParameterizedException if any errors
    */
   public void validateRoles(Set<Role> roles) {
@@ -72,33 +70,9 @@ public class HeeUserValidator {
   }
 
   /**
-   * Validates given password for new users and it should be atleast 8 chars long
+   * Validates given gmc id for users shouldn't be greater than 7 chars long
    *
-   * @param password
-   */
-  public void validatePassword(String password) {
-    if (password == null || StringUtils.isEmpty(password) || password.length() < 8) {
-      throw new CustomParameterizedException("Password should be minimum 8 chars long",
-          ErrorConstants.ERR_VALIDATION);
-    }
-  }
-
-  /**
-   * Validates given password is Temporary for new users and it should be atleast 8 chars long
-   *
-   * @param isTemporaryPassword
-   */
-  public void validateIsTemporary(Boolean isTemporaryPassword) {
-    if (isTemporaryPassword == null) {
-      throw new CustomParameterizedException("isTemporaryPassword should be true or false",
-          ErrorConstants.ERR_VALIDATION);
-    }
-  }
-
-  /**
-   * Validates given gmc id for users and it shouldn't be greater than 7 chars long
-   *
-   * @param gmcId
+   * @param gmcId The identifier given to a doctor by the GMC
    */
   public void validateGmcId(String gmcId) {
     if (gmcId != null && gmcId.length() > 7) {

--- a/profile-service/src/main/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResource.java
+++ b/profile-service/src/main/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResource.java
@@ -87,11 +87,6 @@ public class HeeUserResource {
       throws URISyntaxException {
     log.debug("REST request to save HeeUser : {}", heeUserDTO);
     HeeUser heeUser = heeUserMapper.heeUserDTOToHeeUser(heeUserDTO);
-    heeUser.setPassword(heeUserDTO.getPassword());
-    //Validate password
-    heeUserValidator.validatePassword(heeUser.getPassword());
-    //Validate isTemporaryPassword
-    heeUserValidator.validateIsTemporary(heeUser.getTemporaryPassword());
     //Validate
     validateHeeUser(heeUser);
 
@@ -133,7 +128,7 @@ public class HeeUserResource {
     log.debug("REST request to update HeeUser : {}", heeUserDTO);
 
     Optional<HeeUser> dbHeeUser = heeUserRepository.findById(heeUserDTO.getName());
-    if (!dbHeeUser.isPresent()) {
+    if (dbHeeUser.isEmpty()) {
       return createHeeUser(heeUserDTO);
     }
     HeeUser heeUser = heeUserMapper.heeUserDTOToHeeUser(heeUserDTO);
@@ -240,7 +235,7 @@ public class HeeUserResource {
     //validate GMC id
     heeUserValidator.validateGmcId(heeUser.getGmcId());
     //Validate DBC code
-    heeUserValidator.validateDBCIds(heeUser.getDesignatedBodyCodes());
+    heeUserValidator.validateDbcIds(heeUser.getDesignatedBodyCodes());
     //Validate Role name
     heeUserValidator.validateRoles(heeUser.getRoles());
   }

--- a/profile-service/src/test/java/com/transformuk/hee/tis/profile/validators/HeeUserValidatorTest.java
+++ b/profile-service/src/test/java/com/transformuk/hee/tis/profile/validators/HeeUserValidatorTest.java
@@ -1,6 +1,6 @@
 package com.transformuk.hee.tis.profile.validators;
 
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -14,15 +14,13 @@ import com.transformuk.hee.tis.reference.api.dto.DBCDTO;
 import com.transformuk.hee.tis.reference.api.enums.Status;
 import com.transformuk.hee.tis.reference.client.ReferenceService;
 import java.util.Set;
-
-import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.util.Sets;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -31,29 +29,26 @@ public class HeeUserValidatorTest {
 
   private static final String DBC_ABBR = "DBC_ABBR";
   private static final String DBC = "DBC";
-  private static final String INVAlID_DBC = "INVALID";
+  private static final String INVALID_DBC = "INVALID";
   private static final long ID = 1L;
   private static final long ID_INVALID = 2L;
   private static final String DBC_NAME = "DBC_NAME";
   private static final String ROLENAME = "ROLENAME";
   private static final String PERMISSION_NAME = "PERMISSION_NAME";
   private static final String OTHER_PERMISSION = "OTHER_PERMISSION";
-  private static final String ACCEPTABLEPASSWORD = "ACCEPTABLEPASSWORD";
-  private static final String SHORTPW = "SHORTPW";
   private static final String GMC_ID = "1234567";
   private static final String GMC_ID_TOO_LONG = "12345678";
   @Mock
   RoleRepository roleRepositoryMock;
-  private Set<String> dbcCodes = Sets.newLinkedHashSet(DBC);
-  private Set<String> dbcCodes_invalid = Sets.newLinkedHashSet(INVAlID_DBC);
-  private Set<String> dbcCodes_none = Sets.newLinkedHashSet(HeeUser.NONE);
-  private DBCDTO dbcdto = new DBCDTO();
-  private DBCDTO dbcdto_invalid = new DBCDTO();
-  private Role role = new Role();
-  private Permission permission = new Permission();
-  private Permission permission1 = new Permission();
-  private Set<Role> roles = Sets.newLinkedHashSet(role);
-  private Set<Role> roles_null = Sets.newLinkedHashSet(null);
+  private final Set<String> dbcCodes = Sets.newLinkedHashSet(DBC);
+  private final Set<String> dbcCodesInvalid = Sets.newLinkedHashSet(INVALID_DBC);
+  private final Set<String> dbcCodesNone = Sets.newLinkedHashSet(HeeUser.NONE);
+  private final DBCDTO dbcDto = new DBCDTO();
+  private final DBCDTO dbcDtoInvalid = new DBCDTO();
+  private final Role role = new Role();
+  private final Permission permission = new Permission();
+  private final Permission permission1 = new Permission();
+  private final Set<Role> roles = Sets.newLinkedHashSet(role);
   @Mock
   private ReferenceService referenceServiceMock;
   @InjectMocks
@@ -61,15 +56,15 @@ public class HeeUserValidatorTest {
 
   @Before
   public void setup() {
-    dbcdto.setAbbr(DBC_ABBR);
-    dbcdto.setDbc(DBC);
-    dbcdto.setId(ID);
-    dbcdto.setName(DBC_NAME);
-    dbcdto.setStatus(Status.CURRENT);
+    dbcDto.setAbbr(DBC_ABBR);
+    dbcDto.setDbc(DBC);
+    dbcDto.setId(ID);
+    dbcDto.setName(DBC_NAME);
+    dbcDto.setStatus(Status.CURRENT);
 
-    dbcdto_invalid.setDbc(INVAlID_DBC);
-    dbcdto_invalid.setId(ID_INVALID);
-    dbcdto_invalid.setStatus(Status.CURRENT);
+    dbcDtoInvalid.setDbc(INVALID_DBC);
+    dbcDtoInvalid.setId(ID_INVALID);
+    dbcDtoInvalid.setStatus(Status.CURRENT);
 
     permission.setName(PERMISSION_NAME);
     permission1.setName(OTHER_PERMISSION);
@@ -79,44 +74,44 @@ public class HeeUserValidatorTest {
   }
 
   @Test
-  public void shouldValidateDBCIds() {
+  public void shouldValidateDbcIds() {
     // Given
     when(referenceServiceMock.getDBCByCode(DBC))
-        .thenReturn(new ResponseEntity<>(dbcdto, HttpStatus.OK));
+        .thenReturn(new ResponseEntity<>(dbcDto, HttpStatus.OK));
 
     // When
-    testObj.validateDBCIds(dbcCodes);
+    testObj.validateDbcIds(dbcCodes);
 
     // Then
     verify(referenceServiceMock).getDBCByCode(DBC);
   }
 
   @Test
-  public void shouldValidateInvalidDBCasEmptyReponse() {
+  public void shouldValidateInvalidDbcAsEmptyReponse() {
     // Given
-    when(referenceServiceMock.getDBCByCode(INVAlID_DBC))
-        .thenReturn(new ResponseEntity<DBCDTO>(HttpStatus.NOT_FOUND));
+    when(referenceServiceMock.getDBCByCode(INVALID_DBC))
+        .thenReturn(new ResponseEntity<>(HttpStatus.NOT_FOUND));
 
     // When
-    testObj.validateDBCIds(dbcCodes_invalid);
+    testObj.validateDbcIds(dbcCodesInvalid);
 
     // Then
-    verify(referenceServiceMock).getDBCByCode(INVAlID_DBC);
+    verify(referenceServiceMock).getDBCByCode(INVALID_DBC);
   }
 
   @Test
   public void shouldValidateIfCodeIsNone() {
     // When
-    testObj.validateDBCIds(dbcCodes_none);
+    testObj.validateDbcIds(dbcCodesNone);
 
     // Then
     verify(referenceServiceMock, never()).getDBCByCode(any(String.class));
   }
 
   @Test
-  public void shouldValidateIfSetOfdbcCodesIsNull() {
+  public void shouldValidateIfSetOfDbcCodesIsNull() {
     // When
-    testObj.validateDBCIds(null);
+    testObj.validateDbcIds(null);
 
     // Then
     verify(referenceServiceMock, never()).getDBCByCode(any(String.class));
@@ -151,39 +146,9 @@ public class HeeUserValidatorTest {
   @Test
   public void shouldDealWithNullSetOfRoles() {
     // When
-    testObj.validateRoles(roles_null);
+    testObj.validateRoles(null);
     // Then
     verify(roleRepositoryMock, never()).findByName(any(String.class));
-  }
-
-  @Test
-  public void shouldValidateValidPassword() {
-    testObj.validatePassword(ACCEPTABLEPASSWORD);
-  }
-
-  @Test(expected = CustomParameterizedException.class)
-  public void shouldThrowExceptionIfPasswordTooShort() {
-    testObj.validatePassword(SHORTPW);
-  }
-
-  @Test(expected = CustomParameterizedException.class)
-  public void shouldThrowExceptionIfPasswordEmpty() {
-    testObj.validatePassword(StringUtils.EMPTY);
-  }
-
-  @Test(expected = CustomParameterizedException.class)
-  public void shouldThrowExceptionIfPasswordNull() {
-    testObj.validatePassword(null);
-  }
-
-  @Test
-  public void shouldValidateNonNullTemporaryPassword() {
-    testObj.validateIsTemporary(true);
-  }
-
-  @Test(expected = CustomParameterizedException.class)
-  public void shouldThrowExceptionWithNullTemporaryPassword() {
-    testObj.validateIsTemporary(null);
   }
 
   @Test

--- a/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResourceIntTest.java
+++ b/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResourceIntTest.java
@@ -63,8 +63,6 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest(classes = ProfileApp.class)
 public class HeeUserResourceIntTest {
 
-  private static final String DEFAULT_PASSWORD = "AAAAAAAAAA";
-
   @Autowired
   private HeeUserRepository heeUserRepository;
 
@@ -126,8 +124,6 @@ public class HeeUserResourceIntTest {
     int databaseSizeBeforeCreate = heeUserRepository.findAll().size();
     int databasePermissionSizeBeforeCreate = permissionRepository.findAll().size();
 
-    heeUser.setPassword(DEFAULT_PASSWORD);
-    heeUser.setTemporaryPassword(true);
     // Create the HeeUser
     HeeUserDTO heeUserDTO = heeUserMapper.heeUserToHeeUserDTO(heeUser);
     restHeeUserMockMvc.perform(post("/api/hee-users")
@@ -152,58 +148,12 @@ public class HeeUserResourceIntTest {
 
   @Test
   @Transactional
-  public void shouldValidateTemporaryPassword() throws Exception {
-    int databaseSizeBeforeCreate = heeUserRepository.findAll().size();
-    int databasePermissionSizeBeforeCreate = permissionRepository.findAll().size();
-
-    heeUser.setPassword(DEFAULT_PASSWORD);
-    // Create the HeeUser
-    HeeUserDTO heeUserDTO = heeUserMapper.heeUserToHeeUserDTO(heeUser);
-    restHeeUserMockMvc.perform(post("/api/hee-users")
-            .contentType(TestUtil.JSON)
-            .content(TestUtil.convertObjectToJsonBytes(heeUserDTO)))
-        .andExpect(status().is4xxClientError())
-        .andExpect(jsonPath("$.message").value("isTemporaryPassword should be true or false"));
-
-    // Validate the HeeUser in the database
-    List<HeeUser> heeUserList = heeUserRepository.findAll();
-    assertThat(heeUserList).hasSize(databaseSizeBeforeCreate);
-    assertThat(permissionRepository.findAll()).hasSize(databasePermissionSizeBeforeCreate);
-
-  }
-
-  @Test
-  @Transactional
-  public void shouldValidatePassword() throws Exception {
-    int databaseSizeBeforeCreate = heeUserRepository.findAll().size();
-    int databasePermissionSizeBeforeCreate = permissionRepository.findAll().size();
-
-    heeUser.setPassword(null);
-    // Create the HeeUser
-    HeeUserDTO heeUserDTO = heeUserMapper.heeUserToHeeUserDTO(heeUser);
-    restHeeUserMockMvc.perform(post("/api/hee-users")
-            .contentType(TestUtil.JSON)
-            .content(TestUtil.convertObjectToJsonBytes(heeUserDTO)))
-        .andExpect(status().is4xxClientError())
-        .andExpect(jsonPath("$.message").value("Password should be minimum 8 chars long"));
-
-    // Validate the HeeUser in the database
-    List<HeeUser> heeUserList = heeUserRepository.findAll();
-    assertThat(heeUserList).hasSize(databaseSizeBeforeCreate);
-    assertThat(permissionRepository.findAll()).hasSize(databasePermissionSizeBeforeCreate);
-
-  }
-
-  @Test
-  @Transactional
   public void createHeeUserWithExistingId() throws Exception {
     int databaseSizeBeforeCreate = heeUserRepository.findAll().size();
 
     // Create the HeeUser with an existing name
     heeUser.setName(DEFAULT_NAME);
     HeeUserDTO heeUserDTO = heeUserMapper.heeUserToHeeUserDTO(heeUser);
-    heeUserDTO.setPassword(DEFAULT_PASSWORD);
-    heeUserDTO.setTemporaryPassword(false);
 
     // A user with the same name will update the existing user
     restHeeUserMockMvc.perform(post("/api/hee-users")
@@ -356,8 +306,6 @@ public class HeeUserResourceIntTest {
     heeUserDTO.setName(UPDATED_NAME);
     heeUserDTO.setLastName(UPDATED_NAME);
     heeUserDTO.setEmailAddress("");
-    heeUserDTO.setPassword(DEFAULT_PASSWORD);
-    heeUserDTO.setTemporaryPassword(true);
 
     // If the entity doesn't have an ID, it will be created instead of just being updated
     restHeeUserMockMvc.perform(put("/api/hee-users")


### PR DESCRIPTION
BREAKING CHANGE: Removes password field from DTO

Profile does not use or need the password.
Sending passwords adds unnecessary complexity to new auth flows.

chore: improve code smells and javadoc grammar

TIS21-6435: Adapt UserManagement password section for Cognito