### PR TITLE
refactor: replace Spring Security JwtHelper

### DIFF
--- a/profile-client/pom.xml
+++ b/profile-client/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.transformuk.hee</groupId>
   <artifactId>profile-client</artifactId>
-  <version>3.4.0</version>
+  <version>3.4.1</version>
   <packaging>jar</packaging>
 
   <properties>
@@ -68,6 +68,11 @@
       <groupId>com.netflix.hystrix</groupId>
       <artifactId>hystrix-core</artifactId>
       <version>1.5.18</version>
+    </dependency>
+    <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
+      <version>10.4.2</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
The Spring Security JwtHelper has been deprecated and removed in later version of Spring Security. The recommended replacement is `nimbus-jose-jwt`.

While this is not an immediate issue for TIS services, it's use in the client is a blocker when trying to get the `profile-client` working with later version of Spring.
Considering that this migration will eventually be needed anyway, doing the refactoring now is a light touch to resolve forward-compatibility issues.

TIS21-6233
TIS21-6308