### PR TITLE
fix: remove Reval View permission from unnecessary roles

### DIFF
--- a/profile-service/src/main/resources/db/migration/common/V9.31__remove_reval_permission_from_unnecessary_roles.sql
+++ b/profile-service/src/main/resources/db/migration/common/V9.31__remove_reval_permission_from_unnecessary_roles.sql
@@ -1,0 +1,3 @@
+DELETE FROM `RolePermission`
+WHERE `permissionName` = 'revalidation:see:dbc:trainees'
+AND `roleName` in ('HEE TIS Admin', 'RVOfficer', 'SuperUser'); -- SuperUser is for Stage env only


### PR DESCRIPTION
Had a discussion with Ade A, and both of us think that this permission only needs in the role`HEE Admin Revalidation`.

TIS21-6873