### PR TITLE
Feat: get active HEE users belonging to DBC (for LTFT reassignment)

### DIFF
--- a/profile-service/pom.xml
+++ b/profile-service/pom.xml
@@ -85,6 +85,7 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
+      <version>1.4.200</version>
       <scope>test</scope>
     </dependency>
 

--- a/profile-service/pom.xml
+++ b/profile-service/pom.xml
@@ -12,7 +12,7 @@
 
   <groupId>com.transformuk.hee.tis</groupId>
   <artifactId>profile-service</artifactId>
-  <version>3.10.2</version>
+  <version>3.11.0</version>
   <packaging>war</packaging>
   <name>profile-service</name>
 
@@ -85,7 +85,6 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.4.200</version>
       <scope>test</scope>
     </dependency>
 

--- a/profile-service/src/main/java/com/transformuk/hee/tis/profile/repository/HeeUserRepository.java
+++ b/profile-service/src/main/java/com/transformuk/hee/tis/profile/repository/HeeUserRepository.java
@@ -120,20 +120,18 @@ public interface HeeUserRepository extends JpaRepository<HeeUser, String>,
   List<HeeUser> findHeeUsersByRoleNames(@Param("roleNames") List<String> roleNames);
 
   /**
-   * Finds active users with the specified role who have the given DBC.
+   * Finds active users with the specified role and DBC.
    *
    * @param roleName the role name to filter by
-   * @param ltftDbc the LTFT application's programme DBC
-   * @return list of matching users
+   * @param dbc the DBC with which they must be associated
+   * @return distinct list of matching users
    */
   @Query(value = "select distinct u.* from HeeUser u " +
       "inner join UserRole ur on ur.userName = u.name " +
       "inner join UserDesignatedBody udb on udb.userName = u.name " +
       "where u.active = true " +
       "and ur.roleName = :roleName " +
-      "and udb.designatedBodyCode = :ltftDbc " +
+      "and udb.designatedBodyCode = :dbc " +
       "order by u.firstName, u.lastName", nativeQuery = true)
-  List<HeeUser> findLtftAdminsByRoleAndDbc(
-      @Param("roleName") String roleName,
-      @Param("ltftDbc") String ltftDbc);
+  List<HeeUser> findByRoleAndDbc(@Param("roleName") String roleName, @Param("dbc") String dbc);
 }

--- a/profile-service/src/main/java/com/transformuk/hee/tis/profile/repository/HeeUserRepository.java
+++ b/profile-service/src/main/java/com/transformuk/hee/tis/profile/repository/HeeUserRepository.java
@@ -118,4 +118,22 @@ public interface HeeUserRepository extends JpaRepository<HeeUser, String>,
   "where ur.roleName IN (:roleNames)"+
           "AND u.active=true", nativeQuery = true)
   List<HeeUser> findHeeUsersByRoleNames(@Param("roleNames") List<String> roleNames);
+
+  /**
+   * Finds active users with the specified role who have the given DBC.
+   *
+   * @param roleName the role name to filter by
+   * @param ltftDbc the LTFT application's programme DBC
+   * @return list of matching users
+   */
+  @Query(value = "select distinct u.* from HeeUser u " +
+      "inner join UserRole ur on ur.userName = u.name " +
+      "inner join UserDesignatedBody udb on udb.userName = u.name " +
+      "where u.active = true " +
+      "and ur.roleName = :roleName " +
+      "and udb.designatedBodyCode = :ltftDbc " +
+      "order by u.firstName, u.lastName", nativeQuery = true)
+  List<HeeUser> findLtftAdminsByRoleAndDbc(
+      @Param("roleName") String roleName,
+      @Param("ltftDbc") String ltftDbc);
 }

--- a/profile-service/src/main/java/com/transformuk/hee/tis/profile/service/UserService.java
+++ b/profile-service/src/main/java/com/transformuk/hee/tis/profile/service/UserService.java
@@ -70,7 +70,7 @@ public class UserService {
    */
   @Transactional(readOnly = true)
   public List<BasicHeeUserDTO> findLtftAdmins(String roleName, String ltftDbc) {
-    List<HeeUser> heeUsers = heeUserRepository.findLtftAdminsByRoleAndDbc(roleName, ltftDbc);
+    List<HeeUser> heeUsers = heeUserRepository.findByRoleAndDbc(roleName, ltftDbc);
     return heeUserMapper.heeUsersToBasicHeeUserDTOs(heeUsers);
   }
 }

--- a/profile-service/src/main/java/com/transformuk/hee/tis/profile/service/UserService.java
+++ b/profile-service/src/main/java/com/transformuk/hee/tis/profile/service/UserService.java
@@ -60,4 +60,17 @@ public class UserService {
     List<BasicHeeUserDTO> heeUserDTOs = heeUserMapper.heeUsersToBasicHeeUserDTOs(heeUsers);
     return heeUserDTOs;
   }
+
+  /**
+   * Find LTFT admin candidates who have the specified role and the LTFT programme's DBC.
+   *
+   * @param roleName the role name to filter by
+   * @param ltftDbc the LTFT application's programme DBC
+   * @return list of matching admin DTOs
+   */
+  @Transactional(readOnly = true)
+  public List<BasicHeeUserDTO> findLtftAdmins(String roleName, String ltftDbc) {
+    List<HeeUser> heeUsers = heeUserRepository.findLtftAdminsByRoleAndDbc(roleName, ltftDbc);
+    return heeUserMapper.heeUsersToBasicHeeUserDTOs(heeUsers);
+  }
 }

--- a/profile-service/src/main/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResource.java
+++ b/profile-service/src/main/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResource.java
@@ -7,6 +7,7 @@ import com.transformuk.hee.tis.profile.domain.UserProgramme;
 import com.transformuk.hee.tis.profile.domain.UserTrust;
 import com.transformuk.hee.tis.profile.repository.HeeUserRepository;
 import com.transformuk.hee.tis.profile.repository.UserTrustRepository;
+import com.transformuk.hee.tis.profile.service.LoginService;
 import com.transformuk.hee.tis.profile.service.UserProgrammeService;
 import com.transformuk.hee.tis.profile.service.UserService;
 import com.transformuk.hee.tis.profile.service.UserTrustService;
@@ -37,6 +38,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -49,6 +51,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class HeeUserResource {
 
   private static final String ENTITY_NAME = "heeUser";
+  private static final String LTFT_ADMIN_ROLE = "LTFT Admin";
   private final Logger log = LoggerFactory.getLogger(HeeUserResource.class);
   private final HeeUserRepository heeUserRepository;
   private final HeeUserMapper heeUserMapper;
@@ -56,13 +59,15 @@ public class HeeUserResource {
   private final UserTrustService userTrustService;
   private final UserService userService;
   private final UserProgrammeService userProgrammeService;
+  private final LoginService loginService;
 
   private final HeeUserValidator heeUserValidator;
 
   public HeeUserResource(HeeUserRepository heeUserRepository, HeeUserMapper heeUserMapper,
       HeeUserValidator heeUserValidator,
       UserTrustRepository userTrustRepository, UserTrustService userTrustService,
-      UserProgrammeService userProgrammeService, UserService userService) {
+      UserProgrammeService userProgrammeService, UserService userService,
+      LoginService loginService) {
     this.heeUserRepository = heeUserRepository;
     this.heeUserMapper = heeUserMapper;
     this.heeUserValidator = heeUserValidator;
@@ -70,6 +75,7 @@ public class HeeUserResource {
     this.userTrustService = userTrustService;
     this.userProgrammeService = userProgrammeService;
     this.userService = userService;
+    this.loginService = loginService;
   }
 
   /**
@@ -229,6 +235,33 @@ public class HeeUserResource {
     log.debug("REST request to get HeeUsers with roles : {}", roleNames);
     List<BasicHeeUserDTO> heeUserDTOs = userService.findUsersByRoles(roleNames);
     return ResponseEntity.of(Optional.ofNullable(heeUserDTOs));
+  }
+
+  /**
+   * GET /hee-users/ltft-admins : get admins assignable to an LTFT application.
+   *
+   * <p>Returns active users with the "LTFT Admin" role who have the LTFT application's programme
+   * DBC.
+   *
+   * @param ltftDbc the designated body code of the LTFT application's programme
+   * @return the list of matching admin DTOs
+   */
+  @GetMapping("/hee-users/ltft-admins")
+  @Timed
+  @PreAuthorize("hasAuthority('profile:view:entities')")
+  public ResponseEntity<List<BasicHeeUserDTO>> getLtftAdmins(
+      @RequestParam String ltftDbc,
+      @RequestHeader(value = "Authorization") String authorizationToken) {
+    log.debug("REST request to get LTFT admins for DBC : {}", ltftDbc);
+    String token = authorizationToken.replaceFirst("^Bearer ", "");
+    HeeUser currentUser = loginService.getUserByToken(token);
+    if (!currentUser.getDesignatedBodyCodes().contains(ltftDbc)) {
+      log.info("User {} is not associated with DBC {}, access forbidden",
+          currentUser.getName(), ltftDbc);
+      return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+    }
+    List<BasicHeeUserDTO> admins = userService.findLtftAdmins(LTFT_ADMIN_ROLE, ltftDbc);
+    return ResponseEntity.ok(admins);
   }
 
   private void validateHeeUser(HeeUser heeUser) {

--- a/profile-service/src/main/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResource.java
+++ b/profile-service/src/main/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResource.java
@@ -51,7 +51,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class HeeUserResource {
 
   private static final String ENTITY_NAME = "heeUser";
-  private static final String LTFT_ADMIN_ROLE = "LTFT Admin";
+  private static final String LTFT_ADMIN_ROLE = "NHSE LTFT Admin";
   private final Logger log = LoggerFactory.getLogger(HeeUserResource.class);
   private final HeeUserRepository heeUserRepository;
   private final HeeUserMapper heeUserMapper;

--- a/profile-service/src/test/java/com/transformuk/hee/tis/profile/repository/HeeUserRepositoryTest.java
+++ b/profile-service/src/test/java/com/transformuk/hee/tis/profile/repository/HeeUserRepositoryTest.java
@@ -234,8 +234,8 @@ public class HeeUserRepositoryTest {
     Assert.assertEquals(1, results.size());
     Assert.assertEquals("admin.user", results.get(0).getName());
 
-    roleRepository.deleteById(LTFT_ADMIN_ROLE);
     heeUserRepository.deleteById("admin.user");
+    roleRepository.deleteById(LTFT_ADMIN_ROLE);
   }
 
   @Test
@@ -259,8 +259,8 @@ public class HeeUserRepositoryTest {
     Assert.assertTrue(results.stream()
         .noneMatch(u -> u.getName().equals("admin.other.dbc")));
 
-    roleRepository.deleteById(LTFT_ADMIN_ROLE);
     heeUserRepository.deleteById("admin.other.dbc");
+    roleRepository.deleteById(LTFT_ADMIN_ROLE);
   }
 
   @Test
@@ -284,8 +284,8 @@ public class HeeUserRepositoryTest {
     Assert.assertTrue(results.stream()
         .noneMatch(u -> u.getName().equals("admin.inactive")));
 
-    roleRepository.deleteById(LTFT_ADMIN_ROLE);
     heeUserRepository.deleteById("admin.inactive");
+    roleRepository.deleteById(LTFT_ADMIN_ROLE);
   }
 
   @Test
@@ -312,9 +312,9 @@ public class HeeUserRepositoryTest {
     Assert.assertTrue(results.stream()
         .noneMatch(u -> u.getName().equals("admin.other.role")));
 
+    heeUserRepository.deleteById("admin.other.role");
     roleRepository.deleteById(LTFT_ADMIN_ROLE);
     roleRepository.deleteById("Other Role");
-    heeUserRepository.deleteById("admin.other.role");
   }
 
   @Test
@@ -358,8 +358,8 @@ public class HeeUserRepositoryTest {
     }
     Assert.assertTrue("Anna should appear before Zara", annaIndex < zaraIndex);
 
-    roleRepository.deleteById(LTFT_ADMIN_ROLE);
     heeUserRepository.deleteById("admin.zara");
     heeUserRepository.deleteById("admin.anna");
+    roleRepository.deleteById(LTFT_ADMIN_ROLE);
   }
 }

--- a/profile-service/src/test/java/com/transformuk/hee/tis/profile/repository/HeeUserRepositoryTest.java
+++ b/profile-service/src/test/java/com/transformuk/hee/tis/profile/repository/HeeUserRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.transformuk.hee.tis.profile.repository;
 
-import static org.apache.commons.compress.utils.Sets.newHashSet;
+import static com.google.common.collect.Sets.newHashSet;
+
 import com.transformuk.hee.tis.profile.ProfileApp;
 import com.transformuk.hee.tis.profile.domain.HeeUser;
 import com.transformuk.hee.tis.profile.domain.Role;
@@ -356,6 +357,8 @@ public class HeeUserRepositoryTest {
         zaraIndex = i;
       }
     }
+    Assert.assertTrue("Anna should be present in the results", annaIndex != -1);
+    Assert.assertTrue("Zara should be present in the results", zaraIndex != -1);
     Assert.assertTrue("Anna should appear before Zara", annaIndex < zaraIndex);
 
     heeUserRepository.deleteById("admin.zara");

--- a/profile-service/src/test/java/com/transformuk/hee/tis/profile/repository/HeeUserRepositoryTest.java
+++ b/profile-service/src/test/java/com/transformuk/hee/tis/profile/repository/HeeUserRepositoryTest.java
@@ -357,8 +357,8 @@ public class HeeUserRepositoryTest {
         zaraIndex = i;
       }
     }
-    Assert.assertTrue("Anna should be present in the results", annaIndex != -1);
-    Assert.assertTrue("Zara should be present in the results", zaraIndex != -1);
+    Assert.assertNotEquals("Anna should be present in the results", -1, annaIndex);
+    Assert.assertNotEquals("Zara should be present in the results", -1, zaraIndex);
     Assert.assertTrue("Anna should appear before Zara", annaIndex < zaraIndex);
 
     heeUserRepository.deleteById("admin.zara");

--- a/profile-service/src/test/java/com/transformuk/hee/tis/profile/repository/HeeUserRepositoryTest.java
+++ b/profile-service/src/test/java/com/transformuk/hee/tis/profile/repository/HeeUserRepositoryTest.java
@@ -1,7 +1,9 @@
 package com.transformuk.hee.tis.profile.repository;
 
+import static org.apache.commons.compress.utils.Sets.newHashSet;
 import com.transformuk.hee.tis.profile.ProfileApp;
 import com.transformuk.hee.tis.profile.domain.HeeUser;
+import com.transformuk.hee.tis.profile.domain.Role;
 import com.transformuk.hee.tis.profile.domain.UserTrust;
 import java.util.List;
 import java.util.Optional;
@@ -50,11 +52,16 @@ public class HeeUserRepositoryTest {
   private static final String NAME_3 = "NAME 3";
   private static final String PHONE_NUMBER_3 = "03030303030";
   private static final String NAME_SEARCH_STRING = "Bo";
+  private static final String LTFT_ADMIN_ROLE = "NHSE LTFT Admin";
+  private static final String DBC_1 = "1-AIIDWX";
+  private static final String DBC_2 = "1-OTHER";
 
   @Autowired
   private HeeUserRepository heeUserRepository;
   @Autowired
   private UserTrustRepository userTrustRepository;
+  @Autowired
+  private RoleRepository roleRepository;
 
   private UserTrust userTrust1, userTrust2;
 
@@ -203,5 +210,156 @@ public class HeeUserRepositoryTest {
     return userTrusts.stream()
         .filter(ut -> StringUtils.equals(code, ut.getTrustCode()))
         .findAny();
+  }
+
+  @Test
+  public void findByRoleAndDbcShouldReturnActiveUsersMatchingRoleAndDbc() {
+    Role ltftAdminRole = new Role();
+    ltftAdminRole.setName(LTFT_ADMIN_ROLE);
+    roleRepository.saveAndFlush(ltftAdminRole);
+
+    HeeUser matchingUser = new HeeUser();
+    matchingUser.setName("admin.user");
+    matchingUser.setFirstName("Alice");
+    matchingUser.setLastName("Admin");
+    matchingUser.emailAddress("alice@hee.nhs.uk");
+    matchingUser.setActive(true);
+    matchingUser.setRoles(newHashSet(ltftAdminRole));
+    matchingUser.setDesignatedBodyCodes(newHashSet(DBC_1));
+    heeUserRepository.saveAndFlush(matchingUser);
+
+    List<HeeUser> results = heeUserRepository.findByRoleAndDbc(LTFT_ADMIN_ROLE, DBC_1);
+
+    Assert.assertNotNull(results);
+    Assert.assertEquals(1, results.size());
+    Assert.assertEquals("admin.user", results.get(0).getName());
+
+    roleRepository.deleteById(LTFT_ADMIN_ROLE);
+    heeUserRepository.deleteById("admin.user");
+  }
+
+  @Test
+  public void findByRoleAndDbcShouldNotReturnUsersWithDifferentDbc() {
+    Role ltftAdminRole = new Role();
+    ltftAdminRole.setName(LTFT_ADMIN_ROLE);
+    roleRepository.saveAndFlush(ltftAdminRole);
+
+    HeeUser userWithDifferentDbc = new HeeUser();
+    userWithDifferentDbc.setName("admin.other.dbc");
+    userWithDifferentDbc.setFirstName("Bob");
+    userWithDifferentDbc.setLastName("Admin");
+    userWithDifferentDbc.emailAddress("bob@hee.nhs.uk");
+    userWithDifferentDbc.setActive(true);
+    userWithDifferentDbc.setRoles(newHashSet(ltftAdminRole));
+    userWithDifferentDbc.setDesignatedBodyCodes(newHashSet(DBC_2));
+    heeUserRepository.saveAndFlush(userWithDifferentDbc);
+
+    List<HeeUser> results = heeUserRepository.findByRoleAndDbc(LTFT_ADMIN_ROLE, DBC_1);
+
+    Assert.assertTrue(results.stream()
+        .noneMatch(u -> u.getName().equals("admin.other.dbc")));
+
+    roleRepository.deleteById(LTFT_ADMIN_ROLE);
+    heeUserRepository.deleteById("admin.other.dbc");
+  }
+
+  @Test
+  public void findByRoleAndDbcShouldNotReturnInactiveUsers() {
+    Role ltftAdminRole = new Role();
+    ltftAdminRole.setName(LTFT_ADMIN_ROLE);
+    roleRepository.saveAndFlush(ltftAdminRole);
+
+    HeeUser inactiveUser = new HeeUser();
+    inactiveUser.setName("admin.inactive");
+    inactiveUser.setFirstName("Carol");
+    inactiveUser.setLastName("Admin");
+    inactiveUser.emailAddress("carol@hee.nhs.uk");
+    inactiveUser.setActive(false);
+    inactiveUser.setRoles(newHashSet(ltftAdminRole));
+    inactiveUser.setDesignatedBodyCodes(newHashSet(DBC_1));
+    heeUserRepository.saveAndFlush(inactiveUser);
+
+    List<HeeUser> results = heeUserRepository.findByRoleAndDbc(LTFT_ADMIN_ROLE, DBC_1);
+
+    Assert.assertTrue(results.stream()
+        .noneMatch(u -> u.getName().equals("admin.inactive")));
+
+    roleRepository.deleteById(LTFT_ADMIN_ROLE);
+    heeUserRepository.deleteById("admin.inactive");
+  }
+
+  @Test
+  public void findByRoleAndDbcShouldNotReturnUsersWithDifferentRole() {
+    Role ltftAdminRole = new Role();
+    ltftAdminRole.setName(LTFT_ADMIN_ROLE);
+    Role otherRole = new Role();
+    otherRole.setName("Other Role");
+    roleRepository.saveAndFlush(ltftAdminRole);
+    roleRepository.saveAndFlush(otherRole);
+
+    HeeUser userWithOtherRole = new HeeUser();
+    userWithOtherRole.setName("admin.other.role");
+    userWithOtherRole.setFirstName("Dave");
+    userWithOtherRole.setLastName("Admin");
+    userWithOtherRole.emailAddress("dave@hee.nhs.uk");
+    userWithOtherRole.setActive(true);
+    userWithOtherRole.setRoles(newHashSet(otherRole));
+    userWithOtherRole.setDesignatedBodyCodes(newHashSet(DBC_1));
+    heeUserRepository.saveAndFlush(userWithOtherRole);
+
+    List<HeeUser> results = heeUserRepository.findByRoleAndDbc(LTFT_ADMIN_ROLE, DBC_1);
+
+    Assert.assertTrue(results.stream()
+        .noneMatch(u -> u.getName().equals("admin.other.role")));
+
+    roleRepository.deleteById(LTFT_ADMIN_ROLE);
+    roleRepository.deleteById("Other Role");
+    heeUserRepository.deleteById("admin.other.role");
+  }
+
+  @Test
+  public void findByRoleAndDbcShouldReturnResultsOrderedByFirstNameThenLastName() {
+    Role ltftAdminRole = new Role();
+    ltftAdminRole.setName(LTFT_ADMIN_ROLE);
+    roleRepository.saveAndFlush(ltftAdminRole);
+
+    HeeUser userZara = new HeeUser();
+    userZara.setName("admin.zara");
+    userZara.setFirstName("Zara");
+    userZara.setLastName("Admin");
+    userZara.emailAddress("zara@hee.nhs.uk");
+    userZara.setActive(true);
+    userZara.setRoles(newHashSet(ltftAdminRole));
+    userZara.setDesignatedBodyCodes(newHashSet(DBC_1));
+
+    HeeUser userAnna = new HeeUser();
+    userAnna.setName("admin.anna");
+    userAnna.setFirstName("Anna");
+    userAnna.setLastName("Admin");
+    userAnna.emailAddress("anna@hee.nhs.uk");
+    userAnna.setActive(true);
+    userAnna.setRoles(newHashSet(ltftAdminRole));
+    userAnna.setDesignatedBodyCodes(newHashSet(DBC_1));
+
+    heeUserRepository.saveAndFlush(userZara);
+    heeUserRepository.saveAndFlush(userAnna);
+
+    List<HeeUser> results = heeUserRepository.findByRoleAndDbc(LTFT_ADMIN_ROLE, DBC_1);
+
+    Assert.assertTrue(results.size() >= 2);
+    int annaIndex = -1, zaraIndex = -1;
+    for (int i = 0; i < results.size(); i++) {
+      if ("admin.anna".equals(results.get(i).getName())) {
+        annaIndex = i;
+      }
+      if ("admin.zara".equals(results.get(i).getName())) {
+        zaraIndex = i;
+      }
+    }
+    Assert.assertTrue("Anna should appear before Zara", annaIndex < zaraIndex);
+
+    roleRepository.deleteById(LTFT_ADMIN_ROLE);
+    heeUserRepository.deleteById("admin.zara");
+    heeUserRepository.deleteById("admin.anna");
   }
 }

--- a/profile-service/src/test/java/com/transformuk/hee/tis/profile/service/UserServiceTest.java
+++ b/profile-service/src/test/java/com/transformuk/hee/tis/profile/service/UserServiceTest.java
@@ -207,4 +207,63 @@ public class UserServiceTest {
     List<BasicHeeUserDTO> result = testObj.findUsersByRoles(Arrays.asList("HEE Admin Revalidation"));
     Assert.assertEquals(FIRST_NAME_1, result.get(0).getName());
   }
+
+  @Test
+  public void findLtftAdminsShouldReturnMappedBasicHeeUserDTOs() {
+    String roleName = "NHSE LTFT Admin";
+    String dbc = "1-AIIDWX";
+
+    heeUser1WithTrusts.setName(FIRST_NAME_1);
+    heeUser2EmptyTrusts.setName(FIRST_NAME_2);
+    List<HeeUser> foundUsers = Arrays.asList(heeUser1WithTrusts, heeUser2EmptyTrusts);
+
+    BasicHeeUserDTO basicDto1 = new BasicHeeUserDTO();
+    basicDto1.setName(FIRST_NAME_1);
+    BasicHeeUserDTO basicDto2 = new BasicHeeUserDTO();
+    basicDto2.setName(FIRST_NAME_2);
+    List<BasicHeeUserDTO> mappedDtos = Arrays.asList(basicDto1, basicDto2);
+
+    when(heeUserRepositoryMock.findByRoleAndDbc(roleName, dbc)).thenReturn(foundUsers);
+    when(heeUserMapperMock.heeUsersToBasicHeeUserDTOs(foundUsers)).thenReturn(mappedDtos);
+
+    List<BasicHeeUserDTO> result = testObj.findLtftAdmins(roleName, dbc);
+
+    Assert.assertEquals(2, result.size());
+    Assert.assertEquals(FIRST_NAME_1, result.get(0).getName());
+    Assert.assertEquals(FIRST_NAME_2, result.get(1).getName());
+
+    verify(heeUserRepositoryMock).findByRoleAndDbc(roleName, dbc);
+    verify(heeUserMapperMock).heeUsersToBasicHeeUserDTOs(foundUsers);
+  }
+
+  @Test
+  public void findLtftAdminsShouldReturnEmptyListWhenNoUsersFound() {
+    String roleName = "NHSE LTFT Admin";
+    String dbc = "1-AIIDWX";
+
+    when(heeUserRepositoryMock.findByRoleAndDbc(roleName, dbc)).thenReturn(Collections.emptyList());
+    when(heeUserMapperMock.heeUsersToBasicHeeUserDTOs(Collections.emptyList()))
+        .thenReturn(Collections.emptyList());
+
+    List<BasicHeeUserDTO> result = testObj.findLtftAdmins(roleName, dbc);
+
+    Assert.assertNotNull(result);
+    Assert.assertTrue(result.isEmpty());
+
+    verify(heeUserRepositoryMock).findByRoleAndDbc(roleName, dbc);
+    verify(heeUserMapperMock).heeUsersToBasicHeeUserDTOs(Collections.emptyList());
+  }
+
+  @Test
+  public void findLtftAdminsShouldPassRoleNameAndDbcToRepository() {
+    String roleName = "NHSE LTFT Admin";
+    String dbc = "1-AIIDWX";
+
+    when(heeUserRepositoryMock.findByRoleAndDbc(roleName, dbc)).thenReturn(Collections.emptyList());
+    when(heeUserMapperMock.heeUsersToBasicHeeUserDTOs(any())).thenReturn(Collections.emptyList());
+
+    testObj.findLtftAdmins(roleName, dbc);
+
+    verify(heeUserRepositoryMock).findByRoleAndDbc(roleName, dbc);
+  }
 }

--- a/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResourceInt2Test.java
+++ b/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResourceInt2Test.java
@@ -11,6 +11,7 @@ import com.google.common.collect.Lists;
 import com.transformuk.hee.tis.profile.ProfileApp;
 import com.transformuk.hee.tis.profile.repository.HeeUserRepository;
 import com.transformuk.hee.tis.profile.repository.UserTrustRepository;
+import com.transformuk.hee.tis.profile.service.LoginService;
 import com.transformuk.hee.tis.profile.service.UserProgrammeService;
 import com.transformuk.hee.tis.profile.service.UserService;
 import com.transformuk.hee.tis.profile.service.UserTrustService;
@@ -59,6 +60,8 @@ public class HeeUserResourceInt2Test {
   private UserProgrammeService userProgrammeService;
   @MockBean
   private UserService userServiceMock;
+  @MockBean
+  private LoginService loginServiceMock;
 
   @Autowired
   private PageableArgumentResolver pageableArgumentResolver;
@@ -79,7 +82,8 @@ public class HeeUserResourceInt2Test {
         userTrustRepositoryMock,
         userTrustServiceMock,
         userProgrammeService,
-        userServiceMock);
+        userServiceMock,
+        loginServiceMock);
     this.restHeeUserMockMvc = MockMvcBuilders.standaloneSetup(heeUserResource)
         .setCustomArgumentResolvers(pageableArgumentResolver)
         .setControllerAdvice(exceptionTranslator)

--- a/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResourceInt2Test.java
+++ b/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResourceInt2Test.java
@@ -1,5 +1,6 @@
 package com.transformuk.hee.tis.profile.web.rest;
 
+import static com.google.common.collect.Sets.newHashSet;
 import static org.hamcrest.Matchers.hasItems;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -8,7 +9,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
 import com.transformuk.hee.tis.profile.ProfileApp;
 import com.transformuk.hee.tis.profile.domain.HeeUser;
 import com.transformuk.hee.tis.profile.repository.HeeUserRepository;
@@ -182,7 +182,7 @@ public class HeeUserResourceInt2Test {
 
     HeeUser currentUser = new HeeUser();
     currentUser.setName(TESTNAME_1);
-    currentUser.setDesignatedBodyCodes(Sets.newHashSet(dbc));
+    currentUser.setDesignatedBodyCodes(newHashSet(dbc));
 
     BasicHeeUserDTO admin1 = new BasicHeeUserDTO();
     admin1.setName("admin1");
@@ -209,7 +209,7 @@ public class HeeUserResourceInt2Test {
 
     HeeUser currentUser = new HeeUser();
     currentUser.setName(TESTNAME_1);
-    currentUser.setDesignatedBodyCodes(Sets.newHashSet("1-OTHER"));
+    currentUser.setDesignatedBodyCodes(newHashSet("1-OTHER"));
 
     when(loginServiceMock.getUserByToken(token)).thenReturn(currentUser);
 
@@ -227,7 +227,7 @@ public class HeeUserResourceInt2Test {
 
     HeeUser currentUser = new HeeUser();
     currentUser.setName(TESTNAME_1);
-    currentUser.setDesignatedBodyCodes(Sets.newHashSet(dbc));
+    currentUser.setDesignatedBodyCodes(newHashSet(dbc));
 
     when(loginServiceMock.getUserByToken(token)).thenReturn(currentUser);
     when(userServiceMock.findLtftAdmins("NHSE LTFT Admin", dbc)).thenReturn(new ArrayList<>());

--- a/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResourceInt2Test.java
+++ b/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResourceInt2Test.java
@@ -8,7 +8,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.transformuk.hee.tis.profile.ProfileApp;
+import com.transformuk.hee.tis.profile.domain.HeeUser;
 import com.transformuk.hee.tis.profile.repository.HeeUserRepository;
 import com.transformuk.hee.tis.profile.repository.UserTrustRepository;
 import com.transformuk.hee.tis.profile.service.LoginService;
@@ -171,5 +173,71 @@ public class HeeUserResourceInt2Test {
     restHeeUserMockMvc.perform(get("/api/hee-users-with-roles/{roleNames}", roleNames)
             .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk());
+  }
+
+  @Test
+  public void getLtftAdminsShouldReturnAdminsWhenUserHasDbc() throws Exception {
+    String dbc = "1-AIIDWX";
+    String token = "someJwtToken";
+
+    HeeUser currentUser = new HeeUser();
+    currentUser.setName(TESTNAME_1);
+    currentUser.setDesignatedBodyCodes(Sets.newHashSet(dbc));
+
+    BasicHeeUserDTO admin1 = new BasicHeeUserDTO();
+    admin1.setName("admin1");
+    BasicHeeUserDTO admin2 = new BasicHeeUserDTO();
+    admin2.setName("admin2");
+    List<BasicHeeUserDTO> admins = Lists.newArrayList(admin1, admin2);
+
+    when(loginServiceMock.getUserByToken(token)).thenReturn(currentUser);
+    when(userServiceMock.findLtftAdmins("NHSE LTFT Admin", dbc)).thenReturn(admins);
+
+    restHeeUserMockMvc.perform(get("/api/hee-users/ltft-admins")
+            .param("ltftDbc", dbc)
+            .header("Authorization", "Bearer " + token)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$.[*].name").value(hasItems("admin1", "admin2")));
+  }
+
+  @Test
+  public void getLtftAdminsShouldReturnForbiddenWhenUserDoesNotHaveDbc() throws Exception {
+    String dbc = "1-AIIDWX";
+    String token = "someJwtToken";
+
+    HeeUser currentUser = new HeeUser();
+    currentUser.setName(TESTNAME_1);
+    currentUser.setDesignatedBodyCodes(Sets.newHashSet("1-OTHER"));
+
+    when(loginServiceMock.getUserByToken(token)).thenReturn(currentUser);
+
+    restHeeUserMockMvc.perform(get("/api/hee-users/ltft-admins")
+            .param("ltftDbc", dbc)
+            .header("Authorization", "Bearer " + token)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  public void getLtftAdminsShouldReturnEmptyListWhenNoAdminsFound() throws Exception {
+    String dbc = "1-AIIDWX";
+    String token = "someJwtToken";
+
+    HeeUser currentUser = new HeeUser();
+    currentUser.setName(TESTNAME_1);
+    currentUser.setDesignatedBodyCodes(Sets.newHashSet(dbc));
+
+    when(loginServiceMock.getUserByToken(token)).thenReturn(currentUser);
+    when(userServiceMock.findLtftAdmins("NHSE LTFT Admin", dbc)).thenReturn(new ArrayList<>());
+
+    restHeeUserMockMvc.perform(get("/api/hee-users/ltft-admins")
+            .param("ltftDbc", dbc)
+            .header("Authorization", "Bearer " + token)
+            .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+        .andExpect(jsonPath("$").isEmpty());
   }
 }

--- a/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResourceIntTest.java
+++ b/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResourceIntTest.java
@@ -27,7 +27,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.google.common.collect.Sets;
 import com.transformuk.hee.tis.profile.ProfileApp;
 import com.transformuk.hee.tis.profile.domain.HeeUser;
 import com.transformuk.hee.tis.profile.domain.Permission;
@@ -358,9 +357,7 @@ public class HeeUserResourceIntTest {
   @Test
   @Transactional
   public void getLtftAdminsShouldReturnAdminsWhenRequesterHasMatchingDbc() throws Exception {
-    // findByActive requires inner join on roles AND permissions; use an existing seeded permission
-    Permission requesterPermission = permissionRepository.findById(REQUESTER_PERMISSION)
-        .orElseThrow(() -> new IllegalStateException("Permission not found: " + REQUESTER_PERMISSION));
+    Permission requesterPermission = getOrCreatePermission(REQUESTER_PERMISSION);
 
     Role requesterRole = new Role();
     requesterRole.setName(REQUESTER_ROLE);
@@ -404,9 +401,7 @@ public class HeeUserResourceIntTest {
   @Test
   @Transactional
   public void getLtftAdminsShouldReturnForbiddenWhenRequesterLacksDbc() throws Exception {
-    // findByActive requires inner join on roles AND permissions; use an existing seeded permission
-    Permission requesterPermission = permissionRepository.findById(REQUESTER_PERMISSION)
-        .orElseThrow(() -> new IllegalStateException("Permission not found: " + REQUESTER_PERMISSION));
+    Permission requesterPermission = getOrCreatePermission(REQUESTER_PERMISSION);
 
     Role requesterRole = new Role();
     requesterRole.setName(REQUESTER_ROLE);
@@ -431,9 +426,7 @@ public class HeeUserResourceIntTest {
   @Test
   @Transactional
   public void getLtftAdminsShouldReturnEmptyListWhenNoAdminsHaveMatchingDbc() throws Exception {
-    // findByActive requires inner join on roles AND permissions; use an existing seeded permission
-    Permission requesterPermission = permissionRepository.findById(REQUESTER_PERMISSION)
-        .orElseThrow(() -> new IllegalStateException("Permission not found: " + REQUESTER_PERMISSION));
+    Permission requesterPermission = getOrCreatePermission(REQUESTER_PERMISSION);
 
     Role requesterRole = new Role();
     requesterRole.setName(REQUESTER_ROLE);
@@ -478,5 +471,21 @@ public class HeeUserResourceIntTest {
   @Transactional
   public void equalsVerifier() throws Exception {
     TestUtil.equalsVerifier(HeeUser.class);
+  }
+
+  /**
+   * Helper function to get an existing Permission by name or create and save a new one if it
+   * doesn't exist.
+   *
+   * @param permissionName the name of the Permission to find or create.
+   * @return the existing or newly created Permission.
+   */
+  private Permission getOrCreatePermission(String permissionName) {
+    return permissionRepository.findById(permissionName)
+        .orElseGet(() -> {
+          Permission permission = new Permission();
+          permission.setName(permissionName);
+          return permissionRepository.saveAndFlush(permission);
+        });
   }
 }

--- a/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResourceIntTest.java
+++ b/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResourceIntTest.java
@@ -15,6 +15,7 @@ import static com.transformuk.hee.tis.profile.web.rest.TestUtil.UPDATED_LAST_NAM
 import static com.transformuk.hee.tis.profile.web.rest.TestUtil.UPDATED_NAME;
 import static com.transformuk.hee.tis.profile.web.rest.TestUtil.UPDATED_PHONE_NUMBER;
 import static com.transformuk.hee.tis.profile.web.rest.TestUtil.createEntityHeeUser;
+import static org.apache.commons.compress.utils.Sets.newHashSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.hamcrest.Matchers.hasItem;
@@ -29,6 +30,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.google.common.collect.Sets;
 import com.transformuk.hee.tis.profile.ProfileApp;
 import com.transformuk.hee.tis.profile.domain.HeeUser;
+import com.transformuk.hee.tis.profile.domain.Permission;
 import com.transformuk.hee.tis.profile.domain.Role;
 import com.transformuk.hee.tis.profile.repository.HeeUserRepository;
 import com.transformuk.hee.tis.profile.repository.PermissionRepository;
@@ -71,6 +73,8 @@ public class HeeUserResourceIntTest {
       "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJrcEk5UC1hQ3JaTXJ4cG5aeWNnNnlISk9VZ3g0a2hUYS04TlJyMkRhY0g0In0.eyJqdGkiOiI3ZjJiNzA4MC1lYjYxLTQ1YTgtYmUwNS0xYWFjODNkMTY3ZjciLCJleHAiOjE0Nzc1ODA5ODQsIm5iZiI6MCwiaWF0IjoxNDc3NTgwNjg0LCJpc3MiOiJodHRwczovL2Rldi1hcGkudHJhbnNmb3JtY2xvdWQubmV0L2F1dGgvcmVhbG1zL2xpbiIsImF1ZCI6ImFwaS1nYXRld2F5Iiwic3ViIjoiNGY5YWRhY2MtZjEyNC00M2FmLTkyZDMtYjVlZDc3NjhlYTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYXBpLWdhdGV3YXkiLCJub25jZSI6IlA2NnVVT2JJTVBtY19Wb1RudmlYdk1KWE0zYks0RUo3WHJUeHpRbTN0ZUkiLCJhdXRoX3RpbWUiOjE0Nzc1ODA2ODQsInNlc3Npb25fc3RhdGUiOiIyNzg1NDE2Ny1hNWY0LTRkNTItOGQ3OC02OTY3M2ZmZTMwODgiLCJhY3IiOiIxIiwiY2xpZW50X3Nlc3Npb24iOiIyNjNmZDg1Ni02YmZjLTQ4ZWQtODZlNC1jMzFkOTdmYmNlZGMiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cHM6Ly9kZXYtYXBpLnRyYW5zZm9ybWNsb3VkLm5ldCIsImh0dHBzOi8vYXBwcy5saW4ubmhzLnVrIiwiaHR0cDovL2xvY2FsaG9zdDo4MDg3IiwiaHR0cHM6Ly9zdGFnZS1hcHBzLmxpbi5uaHMudWsiXSwicmVhbG1fYWNjZXNzIjp7InJvbGVzIjpbIlJWQWRtaW4iLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJ2aWV3LXByb2ZpbGUiXX19LCJuYW1lIjoiSmFtZXMgSHVkc29uIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiamFtZXNoIiwiZ2l2ZW5fbmFtZSI6IkphbWVzIiwiZmFtaWx5X25hbWUiOiJIdWRzb24ifQ.VJ_8MDyM-1_MMlmhl4N-ZXHyq0G8AlaSLBR4eqlrXLD5CC29dW807WARalNGDqwlNSUuvK6tDiGRt5XKYWo6HDNBL-7Sp3QT2FXew6dD8zJwN8iR34aJGDGg94Kd0PkFESybqQFb4-sntCfKHQ3aRZkpD2WkyNZXEQEuDURYuqyJulqmKXqZxfnYWkd8JgSN1oTyUc4sFPWHjzI9A_y_0Tb13hAvFlPFWwKhCSSZqjRtC65JADOYMeIbyPCsSCKq0DqY2DCZpBivp5Wp0sZu0SSkww_rkwV5tql4gXV5kYmHWJa1rx_OmTAv6UKWYG4aFaqGmvcNhXkZGrweSCEmUw";
   private static final String LTFT_ADMIN_ROLE = "NHSE LTFT Admin";
   private static final String LTFT_DBC = "1-LTFT-TEST";
+  private static final String REQUESTER_ROLE = "HEE Requester";
+  private static final String REQUESTER_PERMISSION = "profile:view:entities";
 
   @Autowired
   private HeeUserRepository heeUserRepository;
@@ -354,18 +358,28 @@ public class HeeUserResourceIntTest {
   @Test
   @Transactional
   public void getLtftAdminsShouldReturnAdminsWhenRequesterHasMatchingDbc() throws Exception {
-    // Save the LTFT Admin role
+    // findByActive requires inner join on roles AND permissions; use an existing seeded permission
+    Permission requesterPermission = permissionRepository.findById(REQUESTER_PERMISSION)
+        .orElseThrow(() -> new IllegalStateException("Permission not found: " + REQUESTER_PERMISSION));
+
+    Role requesterRole = new Role();
+    requesterRole.setName(REQUESTER_ROLE);
+    requesterRole.setPermissions(newHashSet(requesterPermission));
+    roleRepository.saveAndFlush(requesterRole);
+
     Role ltftAdminRole = new Role();
     ltftAdminRole.setName(LTFT_ADMIN_ROLE);
+    ltftAdminRole.setPermissions(newHashSet(requesterPermission));
     roleRepository.saveAndFlush(ltftAdminRole);
 
-    // Save the requesting user (decoded from TOKEN: preferred_username = "jamesh") with the DBC
+    // Save the requesting user with a different DBC, not matching ltftDbc
     HeeUser requester = new HeeUser();
     requester.setName("jamesh");
     requester.setLastName("Hudson");
     requester.setEmailAddress("jamesh@hee.nhs.uk");
     requester.setActive(true);
-    requester.setDesignatedBodyCodes(Sets.newHashSet(LTFT_DBC));
+    requester.setRoles(newHashSet(requesterRole));
+    requester.setDesignatedBodyCodes(newHashSet(LTFT_DBC));
     heeUserRepository.saveAndFlush(requester);
 
     // Save an active LTFT admin with the matching role and DBC
@@ -375,8 +389,8 @@ public class HeeUserResourceIntTest {
     ltftAdmin.setLastName("User");
     ltftAdmin.setEmailAddress("admin@hee.nhs.uk");
     ltftAdmin.setActive(true);
-    ltftAdmin.setRoles(Sets.newHashSet(ltftAdminRole));
-    ltftAdmin.setDesignatedBodyCodes(Sets.newHashSet(LTFT_DBC));
+    ltftAdmin.setRoles(newHashSet(ltftAdminRole));
+    ltftAdmin.setDesignatedBodyCodes(newHashSet(LTFT_DBC));
     heeUserRepository.saveAndFlush(ltftAdmin);
 
     restHeeUserMockMvc.perform(get("/api/hee-users/ltft-admins")
@@ -390,13 +404,22 @@ public class HeeUserResourceIntTest {
   @Test
   @Transactional
   public void getLtftAdminsShouldReturnForbiddenWhenRequesterLacksDbc() throws Exception {
-    // Save the requesting user with a different DBC, not matching ltftDbc
+    // findByActive requires inner join on roles AND permissions; use an existing seeded permission
+    Permission requesterPermission = permissionRepository.findById(REQUESTER_PERMISSION)
+        .orElseThrow(() -> new IllegalStateException("Permission not found: " + REQUESTER_PERMISSION));
+
+    Role requesterRole = new Role();
+    requesterRole.setName(REQUESTER_ROLE);
+    requesterRole.setPermissions(newHashSet(requesterPermission));
+    roleRepository.saveAndFlush(requesterRole);
+
     HeeUser requester = new HeeUser();
     requester.setName("jamesh");
     requester.setLastName("Hudson");
     requester.setEmailAddress("jamesh@hee.nhs.uk");
     requester.setActive(true);
-    requester.setDesignatedBodyCodes(Sets.newHashSet("1-OTHER-DBC"));
+    requester.setRoles(newHashSet(requesterRole));
+    requester.setDesignatedBodyCodes(newHashSet("1-OTHER-DBC"));
     heeUserRepository.saveAndFlush(requester);
 
     restHeeUserMockMvc.perform(get("/api/hee-users/ltft-admins")
@@ -408,18 +431,28 @@ public class HeeUserResourceIntTest {
   @Test
   @Transactional
   public void getLtftAdminsShouldReturnEmptyListWhenNoAdminsHaveMatchingDbc() throws Exception {
-    // Save the LTFT Admin role
+    // findByActive requires inner join on roles AND permissions; use an existing seeded permission
+    Permission requesterPermission = permissionRepository.findById(REQUESTER_PERMISSION)
+        .orElseThrow(() -> new IllegalStateException("Permission not found: " + REQUESTER_PERMISSION));
+
+    Role requesterRole = new Role();
+    requesterRole.setName(REQUESTER_ROLE);
+    requesterRole.setPermissions(newHashSet(requesterPermission));
+    roleRepository.saveAndFlush(requesterRole);
+
     Role ltftAdminRole = new Role();
     ltftAdminRole.setName(LTFT_ADMIN_ROLE);
+    ltftAdminRole.setPermissions(newHashSet(requesterPermission));
     roleRepository.saveAndFlush(ltftAdminRole);
 
-    // Requester has the DBC
+    // Requester has the DBC; findByActive requires at least one role via inner join
     HeeUser requester = new HeeUser();
     requester.setName("jamesh");
     requester.setLastName("Hudson");
     requester.setEmailAddress("jamesh@hee.nhs.uk");
     requester.setActive(true);
-    requester.setDesignatedBodyCodes(Sets.newHashSet(LTFT_DBC));
+    requester.setRoles(newHashSet(requesterRole));
+    requester.setDesignatedBodyCodes(newHashSet(LTFT_DBC));
     heeUserRepository.saveAndFlush(requester);
 
     // LTFT admin only has a different DBC
@@ -429,8 +462,8 @@ public class HeeUserResourceIntTest {
     ltftAdmin.setLastName("Admin");
     ltftAdmin.setEmailAddress("other@hee.nhs.uk");
     ltftAdmin.setActive(true);
-    ltftAdmin.setRoles(Sets.newHashSet(ltftAdminRole));
-    ltftAdmin.setDesignatedBodyCodes(Sets.newHashSet("1-OTHER-DBC"));
+    ltftAdmin.setRoles(newHashSet(ltftAdminRole));
+    ltftAdmin.setDesignatedBodyCodes(newHashSet("1-OTHER-DBC"));
     heeUserRepository.saveAndFlush(ltftAdmin);
 
     restHeeUserMockMvc.perform(get("/api/hee-users/ltft-admins")

--- a/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResourceIntTest.java
+++ b/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResourceIntTest.java
@@ -33,6 +33,7 @@ import com.transformuk.hee.tis.profile.repository.HeeUserRepository;
 import com.transformuk.hee.tis.profile.repository.PermissionRepository;
 import com.transformuk.hee.tis.profile.repository.UserTrustRepository;
 import com.transformuk.hee.tis.profile.service.UserProgrammeService;
+import com.transformuk.hee.tis.profile.service.LoginService;
 import com.transformuk.hee.tis.profile.service.UserService;
 import com.transformuk.hee.tis.profile.service.UserTrustService;
 import com.transformuk.hee.tis.profile.service.dto.HeeUserDTO;
@@ -96,6 +97,9 @@ public class HeeUserResourceIntTest {
   @Autowired
   private UserService userService;
 
+  @Autowired
+  private LoginService loginService;
+
   private MockMvc restHeeUserMockMvc;
 
   private HeeUser heeUser;
@@ -105,7 +109,7 @@ public class HeeUserResourceIntTest {
   public void setup() {
     HeeUserResource heeUserResource = new HeeUserResource(heeUserRepository, heeUserMapper,
         heeUserValidator, userTrustRepository, userTrustService, userProgrammeService,
-        userService);
+        userService, loginService);
     this.restHeeUserMockMvc = MockMvcBuilders.standaloneSetup(heeUserResource)
         .setCustomArgumentResolvers(pageableArgumentResolver)
         .setControllerAdvice(exceptionTranslator)

--- a/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResourceIntTest.java
+++ b/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResourceIntTest.java
@@ -29,8 +29,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.google.common.collect.Sets;
 import com.transformuk.hee.tis.profile.ProfileApp;
 import com.transformuk.hee.tis.profile.domain.HeeUser;
+import com.transformuk.hee.tis.profile.domain.Role;
 import com.transformuk.hee.tis.profile.repository.HeeUserRepository;
 import com.transformuk.hee.tis.profile.repository.PermissionRepository;
+import com.transformuk.hee.tis.profile.repository.RoleRepository;
 import com.transformuk.hee.tis.profile.repository.UserTrustRepository;
 import com.transformuk.hee.tis.profile.service.UserProgrammeService;
 import com.transformuk.hee.tis.profile.service.LoginService;
@@ -64,11 +66,20 @@ import org.springframework.transaction.annotation.Transactional;
 @SpringBootTest(classes = ProfileApp.class)
 public class HeeUserResourceIntTest {
 
+  // JWT with preferred_username = "jamesh"
+  private static final String TOKEN =
+      "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJrcEk5UC1hQ3JaTXJ4cG5aeWNnNnlISk9VZ3g0a2hUYS04TlJyMkRhY0g0In0.eyJqdGkiOiI3ZjJiNzA4MC1lYjYxLTQ1YTgtYmUwNS0xYWFjODNkMTY3ZjciLCJleHAiOjE0Nzc1ODA5ODQsIm5iZiI6MCwiaWF0IjoxNDc3NTgwNjg0LCJpc3MiOiJodHRwczovL2Rldi1hcGkudHJhbnNmb3JtY2xvdWQubmV0L2F1dGgvcmVhbG1zL2xpbiIsImF1ZCI6ImFwaS1nYXRld2F5Iiwic3ViIjoiNGY5YWRhY2MtZjEyNC00M2FmLTkyZDMtYjVlZDc3NjhlYTU0IiwidHlwIjoiQmVhcmVyIiwiYXpwIjoiYXBpLWdhdGV3YXkiLCJub25jZSI6IlA2NnVVT2JJTVBtY19Wb1RudmlYdk1KWE0zYks0RUo3WHJUeHpRbTN0ZUkiLCJhdXRoX3RpbWUiOjE0Nzc1ODA2ODQsInNlc3Npb25fc3RhdGUiOiIyNzg1NDE2Ny1hNWY0LTRkNTItOGQ3OC02OTY3M2ZmZTMwODgiLCJhY3IiOiIxIiwiY2xpZW50X3Nlc3Npb24iOiIyNjNmZDg1Ni02YmZjLTQ4ZWQtODZlNC1jMzFkOTdmYmNlZGMiLCJhbGxvd2VkLW9yaWdpbnMiOlsiaHR0cHM6Ly9kZXYtYXBpLnRyYW5zZm9ybWNsb3VkLm5ldCIsImh0dHBzOi8vYXBwcy5saW4ubmhzLnVrIiwiaHR0cDovL2xvY2FsaG9zdDo4MDg3IiwiaHR0cHM6Ly9zdGFnZS1hcHBzLmxpbi5uaHMudWsiXSwicmVhbG1fYWNjZXNzIjp7InJvbGVzIjpbIlJWQWRtaW4iLCJ1bWFfYXV0aG9yaXphdGlvbiJdfSwicmVzb3VyY2VfYWNjZXNzIjp7ImFjY291bnQiOnsicm9sZXMiOlsibWFuYWdlLWFjY291bnQiLCJ2aWV3LXByb2ZpbGUiXX19LCJuYW1lIjoiSmFtZXMgSHVkc29uIiwicHJlZmVycmVkX3VzZXJuYW1lIjoiamFtZXNoIiwiZ2l2ZW5fbmFtZSI6IkphbWVzIiwiZmFtaWx5X25hbWUiOiJIdWRzb24ifQ.VJ_8MDyM-1_MMlmhl4N-ZXHyq0G8AlaSLBR4eqlrXLD5CC29dW807WARalNGDqwlNSUuvK6tDiGRt5XKYWo6HDNBL-7Sp3QT2FXew6dD8zJwN8iR34aJGDGg94Kd0PkFESybqQFb4-sntCfKHQ3aRZkpD2WkyNZXEQEuDURYuqyJulqmKXqZxfnYWkd8JgSN1oTyUc4sFPWHjzI9A_y_0Tb13hAvFlPFWwKhCSSZqjRtC65JADOYMeIbyPCsSCKq0DqY2DCZpBivp5Wp0sZu0SSkww_rkwV5tql4gXV5kYmHWJa1rx_OmTAv6UKWYG4aFaqGmvcNhXkZGrweSCEmUw";
+  private static final String LTFT_ADMIN_ROLE = "NHSE LTFT Admin";
+  private static final String LTFT_DBC = "1-LTFT-TEST";
+
   @Autowired
   private HeeUserRepository heeUserRepository;
 
   @Autowired
   private PermissionRepository permissionRepository;
+
+  @Autowired
+  private RoleRepository roleRepository;
 
   @Autowired
   private HeeUserMapper heeUserMapper;
@@ -338,6 +349,96 @@ public class HeeUserResourceIntTest {
     // Validate the database is empty
     List<HeeUser> heeUserList = heeUserRepository.findAll();
     assertThat(heeUserList).hasSize(databaseSizeBeforeDelete - 1);
+  }
+
+  @Test
+  @Transactional
+  public void getLtftAdminsShouldReturnAdminsWhenRequesterHasMatchingDbc() throws Exception {
+    // Save the LTFT Admin role
+    Role ltftAdminRole = new Role();
+    ltftAdminRole.setName(LTFT_ADMIN_ROLE);
+    roleRepository.saveAndFlush(ltftAdminRole);
+
+    // Save the requesting user (decoded from TOKEN: preferred_username = "jamesh") with the DBC
+    HeeUser requester = new HeeUser();
+    requester.setName("jamesh");
+    requester.setLastName("Hudson");
+    requester.setEmailAddress("jamesh@hee.nhs.uk");
+    requester.setActive(true);
+    requester.setDesignatedBodyCodes(Sets.newHashSet(LTFT_DBC));
+    heeUserRepository.saveAndFlush(requester);
+
+    // Save an active LTFT admin with the matching role and DBC
+    HeeUser ltftAdmin = new HeeUser();
+    ltftAdmin.setName("ltft.admin.test");
+    ltftAdmin.setFirstName("Admin");
+    ltftAdmin.setLastName("User");
+    ltftAdmin.setEmailAddress("admin@hee.nhs.uk");
+    ltftAdmin.setActive(true);
+    ltftAdmin.setRoles(Sets.newHashSet(ltftAdminRole));
+    ltftAdmin.setDesignatedBodyCodes(Sets.newHashSet(LTFT_DBC));
+    heeUserRepository.saveAndFlush(ltftAdmin);
+
+    restHeeUserMockMvc.perform(get("/api/hee-users/ltft-admins")
+            .param("ltftDbc", LTFT_DBC)
+            .header("Authorization", "Bearer " + TOKEN))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(TestUtil.JSON))
+        .andExpect(jsonPath("$.[*].name").value(hasItem("ltft.admin.test")));
+  }
+
+  @Test
+  @Transactional
+  public void getLtftAdminsShouldReturnForbiddenWhenRequesterLacksDbc() throws Exception {
+    // Save the requesting user with a different DBC, not matching ltftDbc
+    HeeUser requester = new HeeUser();
+    requester.setName("jamesh");
+    requester.setLastName("Hudson");
+    requester.setEmailAddress("jamesh@hee.nhs.uk");
+    requester.setActive(true);
+    requester.setDesignatedBodyCodes(Sets.newHashSet("1-OTHER-DBC"));
+    heeUserRepository.saveAndFlush(requester);
+
+    restHeeUserMockMvc.perform(get("/api/hee-users/ltft-admins")
+            .param("ltftDbc", LTFT_DBC)
+            .header("Authorization", "Bearer " + TOKEN))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @Transactional
+  public void getLtftAdminsShouldReturnEmptyListWhenNoAdminsHaveMatchingDbc() throws Exception {
+    // Save the LTFT Admin role
+    Role ltftAdminRole = new Role();
+    ltftAdminRole.setName(LTFT_ADMIN_ROLE);
+    roleRepository.saveAndFlush(ltftAdminRole);
+
+    // Requester has the DBC
+    HeeUser requester = new HeeUser();
+    requester.setName("jamesh");
+    requester.setLastName("Hudson");
+    requester.setEmailAddress("jamesh@hee.nhs.uk");
+    requester.setActive(true);
+    requester.setDesignatedBodyCodes(Sets.newHashSet(LTFT_DBC));
+    heeUserRepository.saveAndFlush(requester);
+
+    // LTFT admin only has a different DBC
+    HeeUser ltftAdmin = new HeeUser();
+    ltftAdmin.setName("ltft.admin.other");
+    ltftAdmin.setFirstName("Other");
+    ltftAdmin.setLastName("Admin");
+    ltftAdmin.setEmailAddress("other@hee.nhs.uk");
+    ltftAdmin.setActive(true);
+    ltftAdmin.setRoles(Sets.newHashSet(ltftAdminRole));
+    ltftAdmin.setDesignatedBodyCodes(Sets.newHashSet("1-OTHER-DBC"));
+    heeUserRepository.saveAndFlush(ltftAdmin);
+
+    restHeeUserMockMvc.perform(get("/api/hee-users/ltft-admins")
+            .param("ltftDbc", LTFT_DBC)
+            .header("Authorization", "Bearer " + TOKEN))
+        .andExpect(status().isOk())
+        .andExpect(content().contentType(TestUtil.JSON))
+        .andExpect(jsonPath("$").isEmpty());
   }
 
   @Test

--- a/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResourceIntTest.java
+++ b/profile-service/src/test/java/com/transformuk/hee/tis/profile/web/rest/HeeUserResourceIntTest.java
@@ -1,5 +1,6 @@
 package com.transformuk.hee.tis.profile.web.rest;
 
+import static com.google.common.collect.Sets.newHashSet;
 import static com.transformuk.hee.tis.profile.web.rest.TestUtil.DEFAULT_ACTIVE;
 import static com.transformuk.hee.tis.profile.web.rest.TestUtil.DEFAULT_EMAIL_ADDRESS;
 import static com.transformuk.hee.tis.profile.web.rest.TestUtil.DEFAULT_FIRST_NAME;
@@ -15,7 +16,6 @@ import static com.transformuk.hee.tis.profile.web.rest.TestUtil.UPDATED_LAST_NAM
 import static com.transformuk.hee.tis.profile.web.rest.TestUtil.UPDATED_NAME;
 import static com.transformuk.hee.tis.profile.web.rest.TestUtil.UPDATED_PHONE_NUMBER;
 import static com.transformuk.hee.tis.profile.web.rest.TestUtil.createEntityHeeUser;
-import static org.apache.commons.compress.utils.Sets.newHashSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.hamcrest.Matchers.hasItem;
@@ -134,7 +134,7 @@ public class HeeUserResourceIntTest {
   @Before
   public void initTest() {
     heeUser = createEntityHeeUser();
-    heeUser.setDesignatedBodyCodes(Sets.newHashSet("NONE"));
+    heeUser.setDesignatedBodyCodes(newHashSet("NONE"));
   }
 
   @Test
@@ -372,7 +372,7 @@ public class HeeUserResourceIntTest {
     ltftAdminRole.setPermissions(newHashSet(requesterPermission));
     roleRepository.saveAndFlush(ltftAdminRole);
 
-    // Save the requesting user with a different DBC, not matching ltftDbc
+    // Save the requesting user with the matching DBC so they are authorised to view admins
     HeeUser requester = new HeeUser();
     requester.setName("jamesh");
     requester.setLastName("Hudson");

--- a/profile-service/src/test/resources/config/application.yml
+++ b/profile-service/src/test/resources/config/application.yml
@@ -36,10 +36,11 @@ spring:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
         implicit-strategy: org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl
     properties:
-      hibernate.id.new_generator_mappings: false
+      hibernate.id.new_generator_mappings: true
       hibernate.cache.use_second_level_cache: false
       hibernate.cache.use_query_cache: false
       hibernate.generate_statistics: true
+      hibernate.hbm2ddl.auto: validate
   messages:
     basename: i18n/messages
   mvc:

--- a/profile-service/src/test/resources/config/application.yml
+++ b/profile-service/src/test/resources/config/application.yml
@@ -36,11 +36,10 @@ spring:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
         implicit-strategy: org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl
     properties:
-      hibernate.id.new_generator_mappings: true
+      hibernate.id.new_generator_mappings: false
       hibernate.cache.use_second_level_cache: false
       hibernate.cache.use_query_cache: false
       hibernate.generate_statistics: true
-      hibernate.hbm2ddl.auto: validate
   messages:
     basename: i18n/messages
   mvc:


### PR DESCRIPTION
Search for active users with LTFT Admin permission matching the provided DBC. **We check that the searching user has the DBC as well** (not sure - check this rule: it effectively means that LTFT forms can only be reassigned within a LO, not by an 'external' administrator who is not linked to the LO).  Also, check **sort order**.

Example output: 

```
http://local.tis.com/profile/api/hee-users/ltft-admins?ltftDbc=1-1RSSQ6R

[ {
  "name" : "andre*******@nhs.net",
  "firstName" : "Andrew",
  "lastName" : "Ho****",
  "gmcId" : "000000",
  "emailAddress" : "andre******@nhs.net"
}, {
  "name" : "a.tre*****@nhs.net",
  "firstName" : "Ann",
  "lastName" : "Tre*****",
  "gmcId" : "000000",
  "emailAddress" : "a.tr*****@nhs.net"
}, {
  "name" : "jen*****@nhs.net",
  "firstName" : "Jenny",
  "lastName" : "A*****",
  "gmcId" : "000000",
  "emailAddress" : "jen*****@nhs.net"
}, {
  "name" : "mike.r****@nhs.net",
  "firstName" : "Mike",
  "lastName" : "R****",
  "gmcId" : "000000",
  "emailAddress" : "mike.r****@nhs.net"
}, {
  "name" : "rob.r****@nhs.net",
  "firstName" : "Rob",
  "lastName" : "R****",
  "gmcId" : "000000",
  "emailAddress" : "rob.r*****@nhs.net"
}, {
  "name" : "s.abi****@nhs.net",
  "firstName" : "Shijara",
  "lastName" : "A*****i",
  "gmcId" : "000000",
  "emailAddress" : "s.abi****i@nhs.net"
} ]
```

TIS21-7152
TIS21-7162