### PR TITLE
chore: update JDK for Sonar Analysis

### DIFF
--- a/.github/workflows/ci-cd-workflow.yml
+++ b/.github/workflows/ci-cd-workflow.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           cache: maven
-          distribution: adopt
+          distribution: temurin
           java-version: 11
 
       - name: Configure AWS credentials
@@ -63,8 +63,8 @@ jobs:
         uses: actions/setup-java@v5
         with:
           cache: maven
-          distribution: adopt
-          java-version: 17
+          distribution: temurin
+          java-version: 21
 
       - name: maven-settings-xml-action
         uses: whelk-io/maven-settings-xml-action@v22


### PR DESCRIPTION
1. 'adopt' is a legacy distribution that has been deprecated following the migration of AdoptOpenJDK to Eclipse Adoptium. The recommended replacement is 'temurin', which is already used in the dockerize stage of this workflow.
2. Update JDK of "Set up analysis JDK" to version 21 as we got an error about it: https://github.com/Health-Education-England/TIS-PROFILE/actions/runs/31000611196/job/92288280422

TIS21-8825